### PR TITLE
fix: Drop hostname and pid

### DIFF
--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -1,8 +1,4 @@
-import os from 'os';
-
 export default {
-  pid: process.pid,
-  hostname: os.hostname(),
   build: process.env.BUILD_NUMBER,
   commit: process.env.COMMIT_SHA,
 };


### PR DESCRIPTION
These cost extra bytes and $$$ for every log message. I'm not aware of any benefit to logging these by default given that our primary runtime environments (Fargate, Lambda) are serverless.