### PR TITLE
fix(serializer): Read from `res._header`

### DIFF
--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -109,10 +109,10 @@ describe('res', () => {
   });
 
   test.each`
-    scenario      | value
-    ${'_headers'} | ${{ _headers: { ...headersBase } }}
-    ${'header'}   | ${{ header: { ...headersBase } }}
-    ${'headers'}  | ${{ headers: { ...headersBase } }}
+    scenario     | value
+    ${'_header'} | ${{ _header: { ...headersBase } }}
+    ${'header'}  | ${{ header: { ...headersBase } }}
+    ${'headers'} | ${{ headers: { ...headersBase } }}
   `('maps $scenario', ({ value }) => {
     const result = serializers.res(value);
 

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -16,8 +16,8 @@ interface Response extends Record<string, unknown> {
   status?: number;
 }
 
-const getHeaders = ({ _headers, header, headers }: Response) =>
-  _headers || header || headers;
+const getHeaders = ({ _header, header, headers }: Response) =>
+  _header || header || headers;
 const getStatus = ({ statusCode, status }: Response): number | undefined =>
   statusCode || status;
 


### PR DESCRIPTION
## Purpose
Addresses #9 

## Approach
Make use of `res._header` to get response header info.

## Verification
Making use of serializer in a bare-bones node http server produces the following output:
![image](https://user-images.githubusercontent.com/75303606/106345888-35d7b680-62ee-11eb-87c4-f89cca17aabd.png)

## Notes
With this implementation, response header is provided to logger in a string format:
```
"HTTP/1.1 200 OK\r\ntest-header: abc\r\nDate: Sat, 30 Jan 2021 03:20:32 GMT\r\nConnection: keep-alive\r\nKeep-Alive: timeout=5\r\nContent-Length: 0\r\n\r\n"
```

We _could_ have the response header as key-value pairs by using `res.getHeaders()` which is cleaner and consistent with `req.headers` - see [here](https://nodejs.org/api/http.html#http_response_getheaders). However, the current logger's default configuration does not allow this, because the default formatter/trimmer converts the `getHeaders` method into a string, making it un-callable.