### PR TITLE
fix(package.json): sideEffects is a boolean

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prepush": "yarn test",
     "release": "yarn build && skuba release"
   },
-  "sideEffects": "false",
+  "sideEffects": false,
   "skuba": {
     "entryPoint": "src/index.ts",
     "template": null,


### PR DESCRIPTION
## Purpose

Fix warning found by `esbuild` and `webpack` related to the `sideEffects` property in `package.json`.

## Approach

Change `sideEffects` value in `package.json` from string `"false"` to boolean `false`.

## Notes

Fix is based on the assumption that the property is for consumers of this package that use `webpack`.
See https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

## Issues

Fixes https://github.com/seek-oss/logger/issues/11