### PR TITLE
fix(types): Export Logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export type Logger = pino.Logger;
 export default (
   opts: LoggerOptions = {},
   destination: pino.DestinationStream = pino.destination(1),
-): pino.Logger => {
+): Logger => {
   const formatters = createFormatters(opts);
 
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);


### PR DESCRIPTION
## Purpose

Currently consumers have to specify the type manually (`pino` imports are creeping up in the consumers' code) library does not provide sufficient level of abstraction, so we could use any underlying system without consumers noticing the change or having to fix the types.

## Approach

Export Logger type, manage it internally, have convenience for consumers.

## Migration guide

```diff
-import { P as Pino } from 'pino';
+import { Logger, logger } from '@seek/logger';

- const doStuff = async (logger: Pino.Logger): Promise<void> => {...
+const doStuff = async (logger: Logger): Promise<void> => {...
```
