### PR TITLE
Vendor `redactOptions`

### DIFF
--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -1,10 +1,17 @@
-import type { LoggerOptions } from 'pino';
-
 // TODO: Redact cookies?
 export const defaultRedact = [];
 
+/**
+ * Private interface vendored from `pino`
+ */
+interface redactOptions {
+  paths: string[];
+  censor?: string | ((value: any, path: string[]) => any);
+  remove?: boolean;
+}
+
 export const addDefaultRedactPathStrings = (
-  redact?: LoggerOptions['redact'],
+  redact: string[] | redactOptions | undefined,
 ) => {
   if (!redact) {
     return defaultRedact;


### PR DESCRIPTION
Looks like `tsc --declaration` doesn't like this otherwise.

https://github.com/seek-oss/logger/runs/5999772400?check_suite_focus=true#step:5:38