### PR TITLE
feat: Add `redactText`

### DIFF
--- a/src/destination/index.ts
+++ b/src/destination/index.ts
@@ -1,15 +1,19 @@
 import pino from 'pino';
 
+import { FormatterOptions } from '../formatters';
+
 const bearerMatcher = /\bbearer\s[\w._-]{25,}/gi;
 const redactedDummy = '[Redacted]';
 
 export const withRedaction = (
   dest: pino.DestinationStream,
+  redactLog: FormatterOptions['redactLog'],
 ): pino.DestinationStream => {
   const write = dest.write.bind(dest);
 
   dest.write = (input) => {
-    const redacted = input.replace(bearerMatcher, redactedDummy);
+    let redacted = input.replace(bearerMatcher, redactedDummy);
+    redacted = redactLog?.(redacted, redactedDummy) ?? redacted;
     return write(redacted);
   };
 

--- a/src/destination/index.ts
+++ b/src/destination/index.ts
@@ -7,13 +7,13 @@ const redactedDummy = '[Redacted]';
 
 export const withRedaction = (
   dest: pino.DestinationStream,
-  redactLog: FormatterOptions['redactLog'],
+  redactText: FormatterOptions['redactText'],
 ): pino.DestinationStream => {
   const write = dest.write.bind(dest);
 
   dest.write = (input) => {
     let redacted = input.replace(bearerMatcher, redactedDummy);
-    redacted = redactLog?.(redacted, redactedDummy) ?? redacted;
+    redacted = redactText?.(redacted, redactedDummy) ?? redacted;
     return write(redacted);
   };
 

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -6,6 +6,11 @@ export interface FormatterOptions {
    * Maximum property depth of objects being logged. Default: 4
    */
   maxObjectDepth?: number;
+
+  /**
+   * This allows finer control of redaction by providing access to the full text.
+   */
+  redactLog?: (input: string, redactedDummy: string) => string;
 }
 
 export const createFormatters = (

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -10,7 +10,7 @@ export interface FormatterOptions {
   /**
    * This allows finer control of redaction by providing access to the full text.
    */
-  redactLog?: (input: string, redactedDummy: string) => string;
+  redactText?: (input: string, redactionPlaceholder: string) => string;
 }
 
 export const createFormatters = (

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -409,11 +409,11 @@ testLog(
   },
   'info',
   {
-    redactLog: (input, redactedDummy) => {
+    redactText: (input, redactionPlaceholder) => {
       const regex = /\b(client_secret=)([^&]+)/gi;
       return input.replace(
         regex,
-        (_, group1) => `${group1 as unknown as string}${redactedDummy}`,
+        (_, group1) => `${group1 as unknown as string}${redactionPlaceholder}`,
       );
     },
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -33,14 +33,14 @@ function once(emitter: any, name: any) {
 }
 
 function testLog(
-  testFunc: jest.It,
   testName: string,
   input: any,
   output: any,
   method?: 'error' | 'info',
   loggerOptions?: LoggerOptions,
 ) {
-  testFunc(testName, async () => {
+  // eslint-disable-next-line jest/valid-title
+  test(testName, async () => {
     const inputString = JSON.stringify(input);
     const stream = sink();
     const logger = createLogger({ name: 'my-app', ...loggerOptions }, stream);
@@ -68,7 +68,6 @@ test('it adds user defined base items to the log', async () => {
 });
 
 testLog(
-  test,
   'should log info',
   { key: { foo: 'bar' } },
   {
@@ -79,7 +78,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should log error',
   { key: { foo: 'bar' } },
   {
@@ -91,21 +89,18 @@ testLog(
 );
 
 testLog(
-  test,
   'should serialise request when it is a string',
   { req: 'bar' },
   { req: 'bar' },
 );
 
 testLog(
-  test,
   'should serialise response when it is a string',
   { res: 'foo' },
   { res: 'foo' },
 );
 
 testLog(
-  test,
   'should serialise request when it is an object',
   {
     req: {
@@ -134,7 +129,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should serialise response when it is an object',
   {
     res: {
@@ -152,14 +146,12 @@ testLog(
 );
 
 testLog(
-  test,
   'should truncate objects deeper than the default depth of 4 levels',
   { req: { url: { c: { d: { e: { f: { g: {} } } } } } } },
   { req: { url: { c: { d: '[Object]' } } } },
 );
 
 testLog(
-  test,
   'should truncate objects deeper than the configured object depth',
   { req: { url: { c: { d: { e: { f: { g: {} } } } } } } },
   { req: { url: { c: { d: { e: '[Object]' } } } } },
@@ -168,7 +160,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should truncate Buffers',
   {
     res: {
@@ -179,14 +170,12 @@ testLog(
 );
 
 testLog(
-  test,
   'should truncate strings longer than 512 characters',
   { req: { url: 'a'.repeat(555) } },
   { req: { url: `${'a'.repeat(512)}...` } },
 );
 
 testLog(
-  test,
   'should truncate arrays containing more than 64 items',
   { err: { message: 'a'.repeat(64 + 10).split('') } },
   {
@@ -197,7 +186,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should not truncate arrays containing up to 64 items',
   { err: { message: 'a'.repeat(64).split('') } },
   {
@@ -219,21 +207,18 @@ const manyProps = '?'
   );
 
 testLog(
-  test,
   'should allow up to 64 object properties',
   { props: manyProps },
   { props: manyProps },
 );
 
 testLog(
-  test,
   'should use string representation when object has more than 64 properties',
   { props: { ...manyProps, OneMoreProp: '>_<' } },
   { props: 'Object(65)' },
 );
 
 testLog(
-  test,
   'should log error',
   {
     error: new Error('Ooh oh! Something went wrong'),
@@ -248,7 +233,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should redact reqHeaders object',
   {
     reqHeaders: {
@@ -282,7 +266,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should redact ECONNABORTED error',
   {
     level: 40,
@@ -347,7 +330,6 @@ testLog(
 );
 
 testLog(
-  test,
   'should redact any bearer tokens',
   {
     reqHeaders: {
@@ -401,6 +383,38 @@ testLog(
           _header: getHeaderWithAuth(true),
         },
       },
+    },
+  },
+);
+
+testLog(
+  'allow consumers access to the full text log for redaction',
+  {
+    err: {
+      response: {
+        config: {
+          data: 'client_secret=super_secret_client_secret&audience=https%3A%2F%2Fseek%2Fapi%2Fcandidate',
+        },
+      },
+    },
+  },
+  {
+    err: {
+      response: {
+        config: {
+          data: 'client_secret=[Redacted]&audience=https%3A%2F%2Fseek%2Fapi%2Fcandidate',
+        },
+      },
+    },
+  },
+  'info',
+  {
+    redactLog: (input, redactedDummy) => {
+      const regex = /\b(client_secret=)([^&]+)/gi;
+      return input.replace(
+        regex,
+        (_, group1) => `${group1 as unknown as string}${redactedDummy}`,
+      );
     },
   },
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,5 +39,5 @@ export default (
   };
   opts.timestamp = () => `,"timestamp":"${new Date().toISOString()}"`;
 
-  return pino(opts, withRedaction(destination, opts.redactLog));
+  return pino(opts, withRedaction(destination, opts.redactText));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,5 +39,5 @@ export default (
   };
   opts.timestamp = () => `,"timestamp":"${new Date().toISOString()}"`;
 
-  return pino(opts, withRedaction(destination));
+  return pino(opts, withRedaction(destination, opts.redactLog));
 };


### PR DESCRIPTION
## Purpose

Currently there's no way to redact specific fields within a string, you'd have to redact the entirety of the string via the `redact` option.  

## Approach

This allows consumers to pass in a function that would have access to the full text log, and allow them to redact specific strings within it.

## Notes

N/A

## Issues

Related to https://github.com/SEEK-Jobs/indie-jepsen/pull/240.
