### PR TITLE
feat: Respect custom `timestamp` logger option

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -478,7 +478,7 @@ test('should not log timestamp if timestamp logger option is false', async () =>
   expect(log).not.toHaveProperty('timestamp');
 });
 
-test('should log customized timestamp if timestamp logger option is not false or undefined', async () => {
+test('should log customized timestamp if timestamp logger option is supplied', async () => {
   const mockTimestamp = '1672700973914';
 
   const stream = sink();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -468,8 +468,6 @@ test('should not log timestamp if timestamp logger option is false', async () =>
   logger.info<ExampleMessageContext>(
     {
       activity: 'Testing Logger',
-      // @ts-expect-error
-      propertyNotAllowed: 'Linting error',
       input: {
         foo: 0xf00,
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -455,3 +455,54 @@ test('enforces a specified object interface', async () => {
   expect(log.propertyNotAllowed).toBe('Linting error');
   expect(log.input).toStrictEqual({ foo: 0xf00 });
 });
+
+test('should not log timestamp if timestamp logger option is false', async () => {
+  const stream = sink();
+  const logger = createLogger(
+    {
+      timestamp: false,
+    },
+    stream,
+  );
+
+  logger.info<ExampleMessageContext>(
+    {
+      activity: 'Testing Logger',
+      // @ts-expect-error
+      propertyNotAllowed: 'Linting error',
+      input: {
+        foo: 0xf00,
+      },
+    },
+    'Test log entry',
+  );
+  const log: any = await once(stream, 'data');
+  expect(log).not.toHaveProperty('timestamp');
+});
+
+test('should log customized timestamp if timestamp logger option is not false or undefined', async () => {
+  const mockTimestamp = '1672700973914';
+
+  const stream = sink();
+  const logger = createLogger(
+    {
+      timestamp: () => `,"timestamp":"${mockTimestamp}"`,
+    },
+    stream,
+  );
+
+  logger.info<ExampleMessageContext>(
+    {
+      activity: 'Testing Logger',
+      // @ts-expect-error
+      propertyNotAllowed: 'Linting error',
+      input: {
+        foo: 0xf00,
+      },
+    },
+    'Test log entry',
+  );
+  const log: any = await once(stream, 'data');
+
+  expect(log.timestamp).toBe(mockTimestamp);
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -494,8 +494,6 @@ test('should log customized timestamp if timestamp logger option is not false or
   logger.info<ExampleMessageContext>(
     {
       activity: 'Testing Logger',
-      // @ts-expect-error
-      propertyNotAllowed: 'Linting error',
       input: {
         foo: 0xf00,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,7 @@ export default (
     ...opts.formatters,
   };
 
-  if (opts.timestamp === undefined) {
-    opts.timestamp = () => `,"timestamp":"${new Date().toISOString()}"`;
-  }
+  opts.timestamp ??= () => `,"timestamp":"${new Date().toISOString()}"`;
 
   return pino(opts, withRedaction(destination, opts.redactText));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,10 @@ export default (
     ...formatters,
     ...opts.formatters,
   };
-  opts.timestamp = () => `,"timestamp":"${new Date().toISOString()}"`;
+
+  if (opts.timestamp === undefined) {
+    opts.timestamp = () => `,"timestamp":"${new Date().toISOString()}"`;
+  }
 
   return pino(opts, withRedaction(destination, opts.redactText));
 };


### PR DESCRIPTION
## Purpose

I would like to use provided `timestamp` logger option when creating the logger instance.
Currently, the input `timestamp` logger option is overridden by [the default timestamp function](https://github.com/seek-oss/logger/blob/master/src/index.ts#L40)

## Approach

Use provided `timestamp` logger option if it is not undefined, otherwise use the default timestamp function.

## Notes

This can be a breaking change since several places(e.g. [hirer-contracts-api](https://github.com/SEEK-Jobs/hirer-contracts-api/blob/master/src/util/logger.ts#L16), [hirer-budgets-api](https://github.com/SEEK-Jobs/hirer-budgets-api/blob/master/src/util/logging.ts#L45), and [etc.](https://github.com/search?q=org%3ASEEK-Jobs+%22%40seek%2Flogger%22+createLogger+timestamp&type=Code)) are using the timestamp logger option and this change may generate different timestamp field.

## Issues

Closes #63
