### PR TITLE
fix(serializers): use `.socket()` on the req serializer instead of `.connection()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Release](https://github.com/seek-oss/logger/workflows/Release/badge.svg?branch=master)](https://github.com/seek-oss/logger/actions?query=workflow%3ARelease)
 [![GitHub Validate](https://github.com/seek-oss/logger/workflows/Validate/badge.svg?branch=master)](https://github.com/seek-oss/logger/actions?query=workflow%3AValidate)
-[![Node.js version](https://img.shields.io/badge/node-%3E%3D%208-brightgreen)](https://nodejs.org/en/)
+[![Node.js version](https://img.shields.io/badge/node-%3E%3D%2016.11-brightgreen)](https://nodejs.org/en/)
 [![npm package](https://img.shields.io/npm/v/@seek/logger)](https://www.npmjs.com/package/@seek/logger)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "split2": "4.1.0"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=16.11",
     "npm": ">=5.5.0"
   },
   "publishConfig": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -111,7 +111,7 @@ testLog(
         authorization: bearerToken,
       },
       c: 3,
-      connection: { remoteAddress: '123.234', remotePort: 9999 },
+      socket: { remoteAddress: '123.234', remotePort: 9999 },
     },
   },
   {

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -49,16 +49,16 @@ describe('req', () => {
   });
 
   test.each`
-    scenario                                                         | inputRemoteAddress | inputRemotePort
-    ${'de-nests null connection.remoteAddress'}                      | ${null}            | ${undefined}
-    ${'de-nests null connection.remotePort'}                         | ${undefined}       | ${null}
-    ${'de-nests connection.remoteAddress'}                           | ${remoteAddress}   | ${undefined}
-    ${'de-nests connection.remotePort'}                              | ${undefined}       | ${remotePort}
-    ${'de-nests connection.remoteAddress and connection.remotePort'} | ${remoteAddress}   | ${remotePort}
+    scenario                                                 | inputRemoteAddress | inputRemotePort
+    ${'de-nests null socket.remoteAddress'}                  | ${null}            | ${undefined}
+    ${'de-nests null socket.remotePort'}                     | ${undefined}       | ${null}
+    ${'de-nests socket.remoteAddress'}                       | ${remoteAddress}   | ${undefined}
+    ${'de-nests socket.remotePort'}                          | ${undefined}       | ${remotePort}
+    ${'de-nests socket.remoteAddress and socket.remotePort'} | ${remoteAddress}   | ${remotePort}
   `('$scenario', ({ inputRemoteAddress, inputRemotePort }) => {
     const value = {
       ...requestBase,
-      connection: {
+      socket: {
         remoteAddress: inputRemoteAddress,
         remotePort: inputRemotePort,
       },
@@ -74,15 +74,15 @@ describe('req', () => {
   });
 
   test.each`
-    scenario                                   | value
-    ${'connection is missing'}                 | ${{ ...requestBase }}
-    ${'connection is null'}                    | ${{ ...requestBase, connection: null }}
-    ${'connection is undefined'}               | ${{ ...requestBase, connection: undefined }}
-    ${'connection is empty object'}            | ${{ ...requestBase, connection: {} }}
-    ${'connection.remoteAddress is undefined'} | ${{ ...requestBase, connection: { remoteAddress: undefined } }}
-    ${'connection.remotePort is undefined'}    | ${{ ...requestBase, connection: { remotePort: undefined } }}
-    ${'remoteAddress is a root property'}      | ${{ ...requestBase, remoteAddress }}
-    ${'remotePort is a root property'}         | ${{ ...requestBase, remotePort }}
+    scenario                               | value
+    ${'socket is missing'}                 | ${{ ...requestBase }}
+    ${'socket is null'}                    | ${{ ...requestBase, socket: null }}
+    ${'socket is undefined'}               | ${{ ...requestBase, socket: undefined }}
+    ${'socket is empty object'}            | ${{ ...requestBase, socket: {} }}
+    ${'socket.remoteAddress is undefined'} | ${{ ...requestBase, socket: { remoteAddress: undefined } }}
+    ${'socket.remotePort is undefined'}    | ${{ ...requestBase, socket: { remotePort: undefined } }}
+    ${'remoteAddress is a root property'}  | ${{ ...requestBase, remoteAddress }}
+    ${'remotePort is a root property'}     | ${{ ...requestBase, remotePort }}
   `('remoteAddress and remotePort is undefined when $scenario', ({ value }) => {
     const result = serializers.req(value);
 

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -1,6 +1,6 @@
 import stdSerializers from 'pino-std-serializers';
 
-interface Connection {
+interface Socket {
   remoteAddress?: string;
   remotePort?: string;
 }
@@ -8,7 +8,7 @@ interface Request extends Record<string, unknown> {
   method: string;
   url: string;
   headers: Record<string, string>;
-  connection: Connection;
+  socket: Socket;
 }
 
 interface Response extends Record<string, unknown> {
@@ -32,8 +32,8 @@ const req = (request: Request) =>
         method: request.method,
         url: request.url,
         headers: request.headers,
-        remoteAddress: request?.connection?.remoteAddress,
-        remotePort: request?.connection?.remotePort,
+        remoteAddress: request?.socket?.remoteAddress,
+        remotePort: request?.socket?.remotePort,
       }
     : request;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["ES2019"],
+    "lib": ["ES2022"],
     "outDir": "lib",
     "removeComments": false,
-    "target": "ES2019"
+    "target": "ES2022"
   },
   "exclude": ["lib*/**/*"],
   "extends": "skuba/config/tsconfig.json"


### PR DESCRIPTION
BREAKING CHANGE: Require Node.js 16.11+. Node.js 14 will reach end of life by April 2023.

## Purpose

https://nodejs.org/api/http.html#requestconnection

Accessing `.connection()` on the request object is now deprecated since Node 13. Switch to using `.socket()`

## Approach

_How does this change address the problem?_

## Notes

Let's ship it with https://github.com/seek-oss/logger/pull/59 ?
