### PR TITLE
feat(redact): set redact defaults for req.headers

### DIFF
--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -1,9 +1,9 @@
 // TODO: Redact cookies?
 export const defaultRedact = [
   'req.headers.authorization',
-  'req.headers.authenticated-user',
+  'req.headers["authenticated-user"]',
   'req.headers.cookie',
-  'req.headers.x-seek-oidc-identity',
+  'req.headers["x-seek-oidc-identity"]',
 ];
 
 /**

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -1,5 +1,10 @@
 // TODO: Redact cookies?
-export const defaultRedact = [];
+export const defaultRedact = [
+  'req.headers.authorization',
+  'req.headers.authenticated-user',
+  'req.headers.cookie',
+  'req.headers.x-seek-oidc-identity',
+];
 
 /**
  * Private interface vendored from `pino`


### PR DESCRIPTION
## Purpose

We have a serializer for the req object which by default serializes the headers path. We should probably set up redact on some default sensitive paths. https://github.com/seek-oss/koala/blob/6c922f0c3ba60fd6db841b47fd535397a889a385/src/requestLogging/requestLogging.ts#L35

## Approach

Set some common redact paths.

## Notes

<img width="368" alt="image" src="https://user-images.githubusercontent.com/18017094/226164775-80cfb6af-31c0-47b5-9e14-25ce53985471.png">


## Issues

_Any github issue links related to this PR_
