### PR TITLE
feat: Allow some paths to be redacted and some to be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ logger.error<Fields>(
 
 Bearer tokens are redacted regardless of their placement in the log object.
 
+#### Pino Redaction
+
+To redact other properties, use the `redact` logger options as per [pino redaction] docs.
+
+Pino has a limitation where you can either redact or remove specified `redact.paths` by setting `redact.remove` to `true` or `false`.
+
+A logger option has been added to allow you to redact some paths and remove other paths.
+
+Example:
+
+```typescript
+const logger = createLogger({
+  name: 'my-app',
+  redact: {
+    paths: ['req.headers["x-redact-this"]'],
+    removePaths: ['req.headers["x-remove-this"]'],
+  },
+});
+```
+
 ### Trimming
 
 The following trimming rules apply to all logging data:
@@ -162,3 +182,4 @@ const logger = createLogger({
 [pino]: https://github.com/pinojs/pino
 [pino options]: https://github.com/pinojs/pino/blob/master/docs/api.md#options
 [pino-pretty]: https://github.com/pinojs/pino-pretty
+[pino redaction]: https://github.com/pinojs/pino/blob/master/docs/api.md#redact-array--object

--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ const logger = createLogger({
 });
 ```
 
+#### Removal of Default Properties
+
+The library will remove a set of default properties.  
+To bypass this, set `ignoreDefaultRemovePaths` to `true` on the `redact` options.
+
+Example:
+
+```typescript
+const logger = createLogger({
+  name: 'my-app',
+  redact: {
+    paths: ['req.headers["x-redact-this"]'],
+    removePaths: ['req.headers["x-remove-this"]'],
+    ignoreDefaultRemovePaths: true,
+  },
+});
+```
+
 ### Trimming
 
 The following trimming rules apply to all logging data:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,7 +38,7 @@ function testLog(
   output: any,
   method?: 'error' | 'info',
   loggerOptions?: LoggerOptions,
-  shouldNotHavePropertyPaths?: string[],
+  shouldNotHavePropertyPaths?: Array<string | string[]>,
 ) {
   // eslint-disable-next-line jest/valid-title
   test(testName, async () => {
@@ -470,6 +470,37 @@ testLog(
     },
   },
   ['req.headers.x-remove-me'],
+);
+
+testLog(
+  'should redact or remove specified paths where property names contain dots',
+  {
+    msg: 'allowed',
+    data: {
+      top: {
+        prop1: 'Should be redacted',
+        prop2: 'Should be removed',
+      },
+      ['top.prop1']: 'Should be removed',
+      ['top.prop2']: 'Should be redacted',
+    },
+  },
+  {
+    msg: 'allowed',
+    data: {
+      top: { prop1: '[Redacted]' },
+      ['top.prop2']: '[Redacted]',
+    },
+  },
+  'info',
+  {
+    maxObjectDepth: 20,
+    redact: {
+      paths: ['data.top.prop1', 'data["top.prop2"]'],
+      removePaths: ['data.top.prop2', 'data["top.prop1"]'],
+    },
+  },
+  ['data.top.prop2', ['data', 'top.prop1']],
 );
 
 testLog(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -538,6 +538,98 @@ testLog(
 );
 
 testLog(
+  'should use input censor when redacting',
+  {
+    redact: 'Should be redacted',
+  },
+  {
+    redact: '[SHHH]',
+  },
+  'info',
+  {
+    redact: {
+      paths: ['redact'],
+      censor: (_value, _path) => '[SHHH]',
+    },
+  },
+);
+
+testLog(
+  'should not use input censor when removing',
+  {
+    remove: 'Should be "removed"',
+  },
+  {},
+  'info',
+  {
+    redact: {
+      paths: ['remove'],
+      remove: true,
+      censor: (_value, _path) => 'You have been erased!',
+    },
+  },
+  ['remove'],
+);
+
+testLog(
+  'should not use input censor when redacting and removing with no redact paths',
+  {
+    remove: 'Should be "removed"',
+  },
+  {},
+  'info',
+  {
+    redact: {
+      paths: [],
+      removePaths: ['remove'],
+      censor: (_value, _path) => 'You have been erased!',
+    },
+  },
+  ['remove'],
+);
+
+testLog(
+  'should use input censor function to redact when redacting and removing',
+  {
+    redact: 'Should be redacted',
+    remove: 'Should be "removed"',
+  },
+  {
+    redact: '[SHHH]',
+  },
+  'info',
+  {
+    redact: {
+      paths: ['redact'],
+      removePaths: ['remove'],
+      censor: (_value, path) =>
+        path.includes('redact') ? '[SHHH]' : 'You have been erased!',
+    },
+  },
+  ['remove'],
+);
+
+testLog(
+  'should use input censor text to redact when redacting and removing',
+  {
+    redact: 'Should be redacted',
+    remove: 'Should be "removed"',
+  },
+  {
+    redact: '[SHHH]',
+  },
+  'info',
+  {
+    redact: {
+      paths: ['redact'],
+      removePaths: ['remove'],
+      censor: '[SHHH]',
+    },
+  },
+  ['remove'],
+);
+
+testLog(
   'should remove specified paths',
   {
     msg: 'allowed',

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,7 @@ export default (
     sync: true,
   }),
 ): Logger => {
-  opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
-  opts.redact = redact.configureRedactCensor(opts.redact);
+  opts.redact = redact.configureRedact(opts.redact);
   opts.serializers = {
     ...serializers,
     ...opts.serializers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import serializers from './serializers';
 export { pino };
 
 export type LoggerOptions = Omit<pino.LoggerOptions, 'redact'> &
-  FormatterOptions & { redact?: redact.ExtendedRedactOptions };
+  FormatterOptions & { redact?: redact.ExtendedRedact };
 export type Logger = pino.Logger;
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default (
   }),
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
-  opts.redact = redact.addRemovePathsCensor(opts.redact);
+  opts.redact = redact.configureRedactCensor(opts.redact);
   opts.serializers = {
     ...serializers,
     ...opts.serializers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import serializers from './serializers';
 
 export { pino };
 
-export type LoggerOptions = pino.LoggerOptions & FormatterOptions;
+export type LoggerOptions = Omit<pino.LoggerOptions, 'redact'> &
+  FormatterOptions & { redact?: redact.ExtendedRedactOptions };
 export type Logger = pino.Logger;
 
 /**
@@ -25,6 +26,7 @@ export default (
   }),
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
+  opts.redact = redact.addRemovePathsCensor(opts.redact);
   opts.serializers = {
     ...serializers,
     ...opts.serializers,

--- a/src/redact/index.test.ts
+++ b/src/redact/index.test.ts
@@ -1,0 +1,15 @@
+import { keyFromPath } from '.';
+
+it.each`
+  paths                                          | path
+  ${['data', 'top', 'prop1']}                    | ${'data.top.prop1'}
+  ${['data', 'top.prop1']}                       | ${'data["top.prop1"]'}
+  ${['headers', 'x-request-id']}                 | ${'headers["x-request-id"]'}
+  ${['_start', '$with', 'allowed', 'Char']}      | ${'_start.$with.allowed.Char'}
+  ${['-start', '.with', '4notAllowed', '~Char']} | ${'["-start"][".with"]["4notAllowed"]["~Char"]'}
+  ${['con-tain', 'not!', 'allow∑∂', 'Chår']}     | ${'["con-tain"]["not!"]["allow∑∂"]["Chår"]'}
+`(`should convert '$paths' to '$path'`, ({ paths, path }) => {
+  const result = keyFromPath(paths);
+
+  expect(result).toBe(path);
+});

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -25,6 +25,24 @@ export const addDefaultRedactPathStrings = (
   return redact;
 };
 
+const STARTS_WITH_INVALID_CHARS = '^[^$_a-zA-Z]';
+const CONTAINS_INVALID_CHARS = '[^a-zA-Z0-9_$]+';
+const nonStandardIdentifierRegex = new RegExp(
+  `(${STARTS_WITH_INVALID_CHARS}|${CONTAINS_INVALID_CHARS})`,
+);
+
+export const keyFromPath = (paths: string[]): string => {
+  const path = paths.reduce((previous, current) => {
+    const dotDelimiter = previous === '' ? '' : '.';
+    const escapedPath = nonStandardIdentifierRegex.test(current)
+      ? `["${current}"]`
+      : `${dotDelimiter}${current}`;
+    return `${previous}${escapedPath}`;
+  }, '');
+
+  return path;
+};
+
 export const addRemovePathsCensor = (
   redact: ExtendedRedact,
 ): ExtendedRedact => {
@@ -49,6 +67,6 @@ export const addRemovePathsCensor = (
     : {
         paths: [...redactPaths, ...removePaths],
         censor: (_value, path) =>
-          redactMap[path.join('.')] ? '[Redacted]' : undefined,
+          redactMap[keyFromPath(path)] ? '[Redacted]' : undefined,
       };
 };

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -13,7 +13,7 @@ export type ExtendedRedactOptions = pino.LoggerOptions['redact'] & {
 
 type ExtendedRedact = string[] | ExtendedRedactOptions | undefined;
 
-export const addDefaultRedactPathStrings = (
+const addDefaultRedactPathStrings = (
   redact: ExtendedRedact,
 ): ExtendedRedact => {
   if (!redact) {
@@ -43,9 +43,7 @@ export const keyFromPath = (paths: string[]): string => {
   return path;
 };
 
-export const configureRedactCensor = (
-  redact: ExtendedRedact,
-): ExtendedRedact => {
+const configureRedactCensor = (redact: ExtendedRedact): ExtendedRedact => {
   if (
     !redact ||
     Array.isArray(redact) ||
@@ -66,3 +64,6 @@ export const configureRedactCensor = (
           redactSet.has(keyFromPath(path)) ? '[Redacted]' : undefined,
       };
 };
+
+export const configureRedact = (redact: ExtendedRedact): ExtendedRedact =>
+  configureRedactCensor(addDefaultRedactPathStrings(redact));

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -69,15 +69,20 @@ const configureRedactCensor = (redact: ExtendedRedact): ExtendedRedact => {
     return redact;
   }
 
-  const { paths: redactPaths, removePaths } = redact;
-  const redactSet = new Set(redactPaths);
+  const { paths: redactPaths, removePaths, censor } = redact;
+  const removeSet = new Set(removePaths);
+  const censorText = typeof censor === 'string' ? censor : '[Redacted]';
+  const censorPath = (value: unknown, path: string[]): unknown =>
+    typeof censor === 'function' ? censor(value, path) : censorText;
 
   return redactPaths.length === 0
-    ? { paths: removePaths, remove: true }
+    ? { paths: removePaths, remove: true, censor }
     : {
         paths: [...redactPaths, ...removePaths],
-        censor: (_value, path) =>
-          redactSet.has(keyFromPath(path)) ? '[Redacted]' : undefined,
+        censor: (value, path) =>
+          removeSet.has(keyFromPath(path))
+            ? undefined
+            : censorPath(value, path),
       };
 };
 

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -39,11 +39,16 @@ export const addRemovePathsCensor = (
 
   const { paths: redactPaths, removePaths } = redact;
 
+  const redactMap = redactPaths.reduce(
+    (previous, current) => ({ ...previous, [current]: true }),
+    {} as Record<string, boolean>,
+  );
+
   return redactPaths.length === 0
     ? { paths: removePaths, remove: true }
     : {
         paths: [...redactPaths, ...removePaths],
         censor: (_value, path) =>
-          redactPaths.includes(path.join('.')) ? '[Redacted]' : undefined,
+          redactMap[path.join('.')] ? '[Redacted]' : undefined,
       };
 };

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -56,17 +56,13 @@ export const configureRedactCensor = (
   }
 
   const { paths: redactPaths, removePaths } = redact;
-
-  const redactMap = redactPaths.reduce(
-    (previous, current) => ({ ...previous, [current]: true }),
-    {} as Record<string, boolean>,
-  );
+  const redactSet = new Set(redactPaths);
 
   return redactPaths.length === 0
     ? { paths: removePaths, remove: true }
     : {
         paths: [...redactPaths, ...removePaths],
         censor: (_value, path) =>
-          redactMap[keyFromPath(path)] ? '[Redacted]' : undefined,
+          redactSet.has(keyFromPath(path)) ? '[Redacted]' : undefined,
       };
 };

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -43,7 +43,7 @@ export const keyFromPath = (paths: string[]): string => {
   return path;
 };
 
-export const addRemovePathsCensor = (
+export const configureRedactCensor = (
   redact: ExtendedRedact,
 ): ExtendedRedact => {
   if (


### PR DESCRIPTION
## Purpose

Pino has a limitation where you can either redact or remove specified `redact.paths` by setting `redact.remove` to `true` or `false`.

In some cases, it's reasonable to want to redact some properties e.g. `headers.authorization` so you know that you have an authorization header but in other cases, the header, e.g. `x-envoy-peer-metadata` only contributes to increasing the log message size and therefore cost.

To reduce costs, we should be able to remove the properties that are not relevant for diagnostic purposes.

## Approach

A `removePaths` logger option has been added to allow you to redact some paths and remove other paths.

Example:

```typescript
const logger = createLogger({
  name: 'my-app',
  redact: {
    paths: ['req.headers["x-redact-this"]'],
    removePaths: ['req.headers["x-remove-this"]'],
  },
});
```

Default paths can be added for removal if needed (currently an empty list):

https://github.com/seek-oss/logger/blob/9c16ede05fbc22a3f7df9ffbe455d36e6a0b4bb6/src/redact/index.ts#L6

If you'd prefer not to remove the default paths, you can opt out by setting `ignoreDefaultRemovePaths` to `true`.

Example:

```typescript
const logger = createLogger({
  name: 'my-app',
  redact: {
    paths: ['req.headers["x-redact-this"]'],
    removePaths: ['req.headers["x-remove-this"]'],
    ignoreDefaultRemovePaths: true,
  },
});
```

## Notes

1. Reverted https://github.com/seek-oss/logger/pull/42 to allow `redactOptions` to be extended.  
   Running `yarn build` succeeds without errors.
3. Added an expectation in the test for properties not to be present.

## Issues

Resolves https://github.com/seek-oss/logger/issues/83
