### PR TITLE
feat: Omit specific headers by default

### DIFF
--- a/.changeset/moody-bobcats-travel.md
+++ b/.changeset/moody-bobcats-travel.md
@@ -1,0 +1,28 @@
+---
+'@seek/logger': major
+---
+
+Omit a default set or the specified headers from the logged object
+
+By default, the following headers in the `headers` and `req.headers`
+properties will be omitted from the logged object:
+
+- 'x-envoy-attempt-count'
+- 'x-envoy-decorator-operation'
+- 'x-envoy-expected-rq-timeout-ms'
+- 'x-envoy-external-address'
+- 'x-envoy-internal'
+- 'x-envoy-peer-metadata'
+- 'x-envoy-peer-metadata-id'
+- 'x-envoy-upstream-service-time'
+
+If you would like to opt out of this, you can provide an empty list or your
+own list of headers to omit in the `omitHeaderNames` property when creating
+your logger e.g.
+
+```typescript
+const logger = createLogger({
+  name: 'my-app',
+  omitHeaderNames: ['dnt', 'sec-fetch-dest'],
+});
+```

--- a/.changeset/moody-bobcats-travel.md
+++ b/.changeset/moody-bobcats-travel.md
@@ -2,27 +2,36 @@
 '@seek/logger': minor
 ---
 
-Omit a default set or the specified headers from the logged object
+Omit request headers
 
-By default, the following headers in the `headers` and `req.headers`
-properties will be omitted from the logged object:
+`@seek/logger` now omits the following properties from `headers` and `req.headers` by default:
 
-- 'x-envoy-attempt-count'
-- 'x-envoy-decorator-operation'
-- 'x-envoy-expected-rq-timeout-ms'
-- 'x-envoy-external-address'
-- 'x-envoy-internal'
-- 'x-envoy-peer-metadata'
-- 'x-envoy-peer-metadata-id'
-- 'x-envoy-upstream-service-time'
+- `x-envoy-attempt-count`
+- `x-envoy-decorator-operation`
+- `x-envoy-expected-rq-timeout-ms`
+- `x-envoy-external-address`
+- `x-envoy-internal`
+- `x-envoy-peer-metadata`
+- `x-envoy-peer-metadata-id`
+- `x-envoy-upstream-service-time`
 
-If you would like to opt out of this, you can provide an empty list or your
-own list of headers to omit in the `omitHeaderNames` property when creating
-your logger e.g.
+If you would like to opt out of this behaviours, you can provide an empty list or your own list of request headers to `omitHeaderNames`:
 
-```typescript
+```diff
 const logger = createLogger({
   name: 'my-app',
-  omitHeaderNames: ['dnt', 'sec-fetch-dest'],
++ omitHeaderNames: ['dnt', 'sec-fetch-dest'],
+});
+```
+
+You can also extend the default list like so:
+
+```diff
+- import createLogger from '@seek/logger';
++ import createLogger, { DEFAULT_OMIT_HEADER_NAMES } from '@seek/logger';
+
+const logger = createLogger({
+  name: 'my-app',
++ omitHeaderNames: [...DEFAULT_OMIT_HEADER_NAMES, 'dnt', 'sec-fetch-dest']
 });
 ```

--- a/.changeset/moody-bobcats-travel.md
+++ b/.changeset/moody-bobcats-travel.md
@@ -1,5 +1,5 @@
 ---
-'@seek/logger': major
+'@seek/logger': minor
 ---
 
 Omit a default set or the specified headers from the logged object

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ childLogger.error({ err }, 'Something bad happened');
 
 ### Standardised fields
 
-**@seek/logger** bundles custom `req` and `res` serializers along with [Pino]'s standard set.
+**@seek/logger** bundles custom `req`, `res` and `headers` serializers along with [Pino]'s standard set.
 User-defined serializers will take precedence over predefined ones.
 
 Use the following standardised logging fields to benefit from customised serialization:
@@ -62,6 +62,11 @@ Use the following standardised logging fields to benefit from customised seriali
 - `res` for HTTP responses.
 
   The response object is trimmed to a set of essential fields.
+
+- `headers` for tracing headers.
+
+  Certain headers are omitted by default (e.g. `x-envoy-peer-metadata`).  
+  To opt out of this behavior, set the `omitHeaderNames` logger option to an empty list `[]`.
 
 All other fields will be logged directly.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Use the following standardised logging fields to benefit from customised seriali
 
 - `req` for HTTP requests.
 
-  The request object is trimmed to a set of essential fields.
+  The request object is trimmed to a set of essential fields.  
+  Certain headers are omitted by default (e.g. `x-envoy-peer-metadata`).  
+  To opt out of this behavior, set the `omitHeaderNames` logger option to an empty list `[]`
+  or provide your own list.
 
 - `res` for HTTP responses.
 
@@ -66,7 +69,8 @@ Use the following standardised logging fields to benefit from customised seriali
 - `headers` for tracing headers.
 
   Certain headers are omitted by default (e.g. `x-envoy-peer-metadata`).  
-  To opt out of this behavior, set the `omitHeaderNames` logger option to an empty list `[]`.
+  To opt out of this behavior, set the `omitHeaderNames` logger option to an empty list `[]`
+  or provide your own list.
 
 All other fields will be logged directly.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -574,11 +574,24 @@ testLog(
       ...objectWithDefaultOmitHeaderNameKeys,
       ['x-request-id']: 'some-uuid',
     },
+    req: {
+      headers: {
+        ['authorization']: bearerToken,
+        ...objectWithDefaultOmitHeaderNameKeys,
+        ['x-request-id']: 'some-uuid',
+      },
+    },
   },
   {
     headers: {
       ['authorization']: redactedBearer,
       ['x-request-id']: 'some-uuid',
+    },
+    req: {
+      headers: {
+        ['authorization']: redactedBearer,
+        ['x-request-id']: 'some-uuid',
+      },
     },
   },
   'info',
@@ -592,12 +605,26 @@ testLog(
       ...objectWithDefaultOmitHeaderNameKeys,
       ['x-request-id']: 'some-uuid',
     },
+    req: {
+      headers: {
+        ['authorization']: bearerToken,
+        ...objectWithDefaultOmitHeaderNameKeys,
+        ['x-request-id']: 'some-uuid',
+      },
+    },
   },
   {
     headers: {
       ['authorization']: redactedBearer,
       ...objectWithDefaultOmitHeaderNameKeys,
       ['x-request-id']: 'some-uuid',
+    },
+    req: {
+      headers: {
+        ['authorization']: redactedBearer,
+        ...objectWithDefaultOmitHeaderNameKeys,
+        ['x-request-id']: 'some-uuid',
+      },
     },
   },
   'info',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import split from 'split2';
 
-import { defaultOmitHeaderNames } from './serializers';
+import { DEFAULT_OMIT_HEADER_NAMES } from './serializers';
 
 import createLogger, { type LoggerOptions } from '.';
 
@@ -562,7 +562,7 @@ testLog(
 );
 
 const objectWithDefaultOmitHeaderNameKeys = Object.fromEntries(
-  defaultOmitHeaderNames.map((headerName) => [headerName, 'header value']),
+  DEFAULT_OMIT_HEADER_NAMES.map((headerName) => [headerName, 'header value']),
 );
 
 testLog(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,7 @@
 import split from 'split2';
 
+import { defaultOmitHeaderNames } from './serializers';
+
 import createLogger, { type LoggerOptions } from '.';
 
 const bearerToken =
@@ -557,4 +559,47 @@ testLog(
   {
     maxObjectDepth: 2,
   },
+);
+
+const objectWithDefaultOmitHeaderNameKeys = defaultOmitHeaderNames.reduce(
+  (headers, key) => ({ ...headers, [key]: 'header value' }),
+  {},
+);
+
+testLog(
+  'should omit defaultOmitHeaderNames by default',
+  {
+    headers: {
+      ['authorization']: bearerToken,
+      ...objectWithDefaultOmitHeaderNameKeys,
+      ['x-request-id']: 'some-uuid',
+    },
+  },
+  {
+    headers: {
+      ['authorization']: redactedBearer,
+      ['x-request-id']: 'some-uuid',
+    },
+  },
+  'info',
+);
+
+testLog(
+  'should keep defaultOmitHeaderNames when omitHeaderNames option is empty',
+  {
+    headers: {
+      ['authorization']: bearerToken,
+      ...objectWithDefaultOmitHeaderNameKeys,
+      ['x-request-id']: 'some-uuid',
+    },
+  },
+  {
+    headers: {
+      ['authorization']: redactedBearer,
+      ...objectWithDefaultOmitHeaderNameKeys,
+      ['x-request-id']: 'some-uuid',
+    },
+  },
+  'info',
+  { omitHeaderNames: [] },
 );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -561,9 +561,8 @@ testLog(
   },
 );
 
-const objectWithDefaultOmitHeaderNameKeys = defaultOmitHeaderNames.reduce(
-  (headers, key) => ({ ...headers, [key]: 'header value' }),
-  {},
+const objectWithDefaultOmitHeaderNameKeys = Object.fromEntries(
+  defaultOmitHeaderNames.map((headerName) => [headerName, 'header value']),
 );
 
 testLog(

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,13 @@ export default (
   }),
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
-  opts.serializers = createSerializers(opts);
+
+  const serializers = createSerializers(opts);
+  opts.serializers = {
+    ...serializers,
+    ...opts.serializers,
+  };
+
   const formatters = createFormatters(opts);
   opts.base = {
     ...base,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,17 @@ import base from './base';
 import { withRedaction } from './destination';
 import { type FormatterOptions, createFormatters } from './formatters';
 import * as redact from './redact';
-import serializers from './serializers';
+import defaultSerializers, {
+  type SerializerOptions,
+  defaultOmitHeaderNames,
+} from './serializers';
+import { createOmitPropertiesSerializer } from './serializers/omitPropertiesSerializer';
 
 export { pino };
 
-export type LoggerOptions = pino.LoggerOptions & FormatterOptions;
+export type LoggerOptions = pino.LoggerOptions &
+  FormatterOptions &
+  SerializerOptions;
 export type Logger = pino.Logger;
 
 /**
@@ -25,8 +31,12 @@ export default (
   }),
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
+  const omitHeaderNamesSerializer = createOmitPropertiesSerializer('headers', {
+    omitPropertyNames: opts.omitHeaderNames ?? defaultOmitHeaderNames,
+  });
   opts.serializers = {
-    ...serializers,
+    ...defaultSerializers,
+    ...omitHeaderNamesSerializer,
     ...opts.serializers,
   };
   const formatters = createFormatters(opts);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { type FormatterOptions, createFormatters } from './formatters';
 import * as redact from './redact';
 import { type SerializerOptions, createSerializers } from './serializers';
 
+export { DEFAULT_OMIT_HEADER_NAMES } from './serializers';
+
 export { pino };
 
 export type LoggerOptions = pino.LoggerOptions &

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,7 @@ import base from './base';
 import { withRedaction } from './destination';
 import { type FormatterOptions, createFormatters } from './formatters';
 import * as redact from './redact';
-import defaultSerializers, {
-  type SerializerOptions,
-  defaultOmitHeaderNames,
-} from './serializers';
-import { createOmitPropertiesSerializer } from './serializers/omitPropertiesSerializer';
+import { type SerializerOptions, createSerializers } from './serializers';
 
 export { pino };
 
@@ -31,14 +27,7 @@ export default (
   }),
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
-  const omitHeaderNamesSerializer = createOmitPropertiesSerializer('headers', {
-    omitPropertyNames: opts.omitHeaderNames ?? defaultOmitHeaderNames,
-  });
-  opts.serializers = {
-    ...defaultSerializers,
-    ...omitHeaderNamesSerializer,
-    ...opts.serializers,
-  };
+  opts.serializers = createSerializers(opts);
   const formatters = createFormatters(opts);
   opts.base = {
     ...base,

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -173,3 +173,17 @@ describe('res', () => {
     });
   });
 });
+
+describe('serializers', () => {
+  test('it exports the expected properties', () => {
+    expect(serializers).toMatchInlineSnapshot(`
+      {
+        "err": [Function],
+        "errWithCause": [Function],
+        "headers": [Function],
+        "req": [Function],
+        "res": [Function],
+      }
+    `);
+  });
+});

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -1,4 +1,4 @@
-import { createSerializers, defaultOmitHeaderNames } from '.';
+import { DEFAULT_OMIT_HEADER_NAMES, createSerializers } from '.';
 
 const serializers = createSerializers({});
 
@@ -92,7 +92,7 @@ describe('req', () => {
   });
 
   const objectWithDefaultOmitHeaderNameKeys = Object.fromEntries(
-    defaultOmitHeaderNames.map((headerName) => [headerName, 'header value']),
+    DEFAULT_OMIT_HEADER_NAMES.map((headerName) => [headerName, 'header value']),
   );
 
   it('omits defaultOmitHeaderNames by default', () => {

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -1,4 +1,4 @@
-import serializers from './index';
+import serializers, { type Request, defaultOmitHeaderNames } from './index';
 
 describe('req', () => {
   const remoteAddress = '::ffff:123.45.67.89';
@@ -85,6 +85,23 @@ describe('req', () => {
     ${'remotePort is a root property'}     | ${{ ...requestBase, remotePort }}
   `('remoteAddress and remotePort is undefined when $scenario', ({ value }) => {
     const result = serializers.req(value);
+
+    expect(result).toStrictEqual({ ...expectedRequestBase });
+  });
+
+  it('omits defaultOmitHeaderNames by default', () => {
+    const objectWithDefaultOmitHeaderNameKeys = defaultOmitHeaderNames.reduce(
+      (headers, key) => ({ ...headers, [key]: 'header value' }),
+      {},
+    );
+    const request = {
+      ...requestBase,
+      headers: {
+        ...requestBase.headers,
+        ...objectWithDefaultOmitHeaderNameKeys,
+      },
+    } as Partial<Request> as Request;
+    const result = serializers.req(request);
 
     expect(result).toStrictEqual({ ...expectedRequestBase });
   });

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -1,4 +1,10 @@
-import serializers, { type Request, defaultOmitHeaderNames } from './index';
+import {
+  type Request,
+  createSerializers,
+  defaultOmitHeaderNames,
+} from './index';
+
+const serializers = createSerializers({});
 
 describe('req', () => {
   const remoteAddress = '::ffff:123.45.67.89';
@@ -105,6 +111,34 @@ describe('req', () => {
 
     expect(result).toStrictEqual({ ...expectedRequestBase });
   });
+
+  it('omits only specified headers when omitHeaderNames is provided', () => {
+    const objectWithDefaultOmitHeaderNameKeys = defaultOmitHeaderNames.reduce(
+      (headers, key) => ({ ...headers, [key]: 'header value' }),
+      {},
+    );
+    const request = {
+      ...requestBase,
+      headers: {
+        ...requestBase.headers,
+        ['omit-me']: 'header value',
+        ...objectWithDefaultOmitHeaderNameKeys,
+      },
+    } as Partial<Request> as Request;
+
+    const expectedRequest = {
+      ...expectedRequestBase,
+      headers: {
+        ...requestBase.headers,
+        ...objectWithDefaultOmitHeaderNameKeys,
+      },
+    };
+
+    const altSerializers = createSerializers({ omitHeaderNames: ['omit-me'] });
+    const result = altSerializers.req(request);
+
+    expect(result).toStrictEqual(expectedRequest);
+  });
 });
 
 describe('res', () => {
@@ -136,17 +170,6 @@ describe('res', () => {
     expect(result).toStrictEqual({
       statusCode: undefined,
       headers: { ...headersBase },
-    });
-  });
-});
-
-describe('serializers', () => {
-  test('it exports only err, errWithCause, req, res', () => {
-    expect(serializers).toStrictEqual({
-      err: expect.any(Function),
-      errWithCause: expect.any(Function),
-      req: expect.any(Function),
-      res: expect.any(Function),
     });
   });
 });

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -92,31 +92,28 @@ describe('req', () => {
   `('remoteAddress and remotePort is undefined when $scenario', ({ value }) => {
     const result = serializers.req(value);
 
-    expect(result).toStrictEqual({ ...expectedRequestBase });
+    expect(result).toStrictEqual(expectedRequestBase);
   });
 
+  const objectWithDefaultOmitHeaderNameKeys = Object.fromEntries(
+    defaultOmitHeaderNames.map((headerName) => [headerName, 'header value']),
+  );
+
   it('omits defaultOmitHeaderNames by default', () => {
-    const objectWithDefaultOmitHeaderNameKeys = defaultOmitHeaderNames.reduce(
-      (headers, key) => ({ ...headers, [key]: 'header value' }),
-      {},
-    );
     const request = {
       ...requestBase,
       headers: {
         ...requestBase.headers,
         ...objectWithDefaultOmitHeaderNameKeys,
       },
-    } as Partial<Request> as Request;
+    } satisfies Request;
+
     const result = serializers.req(request);
 
-    expect(result).toStrictEqual({ ...expectedRequestBase });
+    expect(result).toStrictEqual(expectedRequestBase);
   });
 
   it('omits only specified headers when omitHeaderNames is provided', () => {
-    const objectWithDefaultOmitHeaderNameKeys = defaultOmitHeaderNames.reduce(
-      (headers, key) => ({ ...headers, [key]: 'header value' }),
-      {},
-    );
     const request = {
       ...requestBase,
       headers: {
@@ -124,7 +121,7 @@ describe('req', () => {
         ['omit-me']: 'header value',
         ...objectWithDefaultOmitHeaderNameKeys,
       },
-    } as Partial<Request> as Request;
+    } satisfies Request;
 
     const expectedRequest = {
       ...expectedRequestBase,

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -1,8 +1,4 @@
-import {
-  type Request,
-  createSerializers,
-  defaultOmitHeaderNames,
-} from './index';
+import { createSerializers, defaultOmitHeaderNames } from '.';
 
 const serializers = createSerializers({});
 
@@ -106,7 +102,7 @@ describe('req', () => {
         ...requestBase.headers,
         ...objectWithDefaultOmitHeaderNameKeys,
       },
-    } satisfies Request;
+    };
 
     const result = serializers.req(request);
 
@@ -121,7 +117,7 @@ describe('req', () => {
         ['omit-me']: 'header value',
         ...objectWithDefaultOmitHeaderNameKeys,
       },
-    } satisfies Request;
+    };
 
     const expectedRequest = {
       ...expectedRequestBase,

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -4,7 +4,7 @@ import { err, errWithCause } from 'pino-std-serializers';
 import { createOmitPropertiesSerializer } from './omitPropertiesSerializer';
 import type { SerializerFn } from './types';
 
-export const defaultOmitHeaderNames = [
+export const DEFAULT_OMIT_HEADER_NAMES = [
   'x-envoy-attempt-count',
   'x-envoy-decorator-operation',
   'x-envoy-expected-rq-timeout-ms',
@@ -16,6 +16,18 @@ export const defaultOmitHeaderNames = [
 ];
 
 export interface SerializerOptions {
+  /**
+   * The request headers to omit from serialized logs.
+   *
+   * The properties listed will be removed under `headers` and `req.headers`.
+   * Matching is currently case sensitive.
+   * You will typically express the header names in lowercase,
+   * as server frameworks normalise incoming headers.
+   *
+   * You can use this option to reduce logging costs.
+   * Defaults to `DEFAULT_OMIT_HEADER_NAMES`,
+   * and can be disabled by supplying an empty array `[]`.
+   */
   omitHeaderNames?: string[];
 }
 
@@ -67,7 +79,7 @@ const res = (response: Response) =>
 
 export const createSerializers = (opts: SerializerOptions) => {
   const serializeHeaders = createOmitPropertiesSerializer(
-    opts.omitHeaderNames ?? defaultOmitHeaderNames,
+    opts.omitHeaderNames ?? DEFAULT_OMIT_HEADER_NAMES,
   );
 
   const serializers = {

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -45,20 +45,19 @@ const isObject = (value: unknown): boolean => {
   return value != null && (type === 'object' || type === 'function');
 };
 
-export const createReqSerializer =
-  (opts: SerializerOptions) => (request: Request) =>
-    isObject(request)
-      ? {
-          method: request.method,
-          url: request.url,
-          headers: omitProperties(
-            request.headers,
-            opts.omitHeaderNames ?? defaultOmitHeaderNames,
-          ),
-          remoteAddress: request?.socket?.remoteAddress,
-          remotePort: request?.socket?.remotePort,
-        }
-      : request;
+const createReqSerializer = (opts: SerializerOptions) => (request: Request) =>
+  isObject(request)
+    ? {
+        method: request.method,
+        url: request.url,
+        headers: omitProperties(
+          request.headers,
+          opts.omitHeaderNames ?? defaultOmitHeaderNames,
+        ),
+        remoteAddress: request?.socket?.remoteAddress,
+        remotePort: request?.socket?.remotePort,
+      }
+    : request;
 
 const res = (response: Response) =>
   isObject(response)

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -65,9 +65,7 @@ const res = (response: Response) =>
       }
     : response;
 
-export const createSerializers = (
-  opts: SerializerOptions & Pick<pino.LoggerOptions, 'serializers'>,
-) => {
+export const createSerializers = (opts: SerializerOptions) => {
   const serializeHeaders = createOmitPropertiesSerializer(
     opts.omitHeaderNames ?? defaultOmitHeaderNames,
   );

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -75,18 +75,11 @@ export const createSerializers = (
     omitPropertyNames: opts.omitHeaderNames ?? defaultOmitHeaderNames,
   });
   return {
-    ...defaultSerializers,
+    err,
+    errWithCause,
     req: createReqSerializer(opts),
+    res,
     ...omitHeaderNamesSerializer,
     ...opts.serializers,
   };
 };
-
-const defaultSerializers = {
-  err,
-  errWithCause,
-  res,
-  req: createReqSerializer({}),
-};
-
-export default defaultSerializers;

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -23,7 +23,7 @@ interface Socket {
   remoteAddress?: string;
   remotePort?: string;
 }
-export interface Request extends Record<string, unknown> {
+interface Request extends Record<string, unknown> {
   method: string;
   url: string;
   headers: Record<string, string>;

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -27,7 +27,7 @@ export interface Request extends Record<string, unknown> {
   method: string;
   url: string;
   headers: Record<string, string>;
-  socket: Socket;
+  socket?: Socket;
 }
 
 interface Response extends Record<string, unknown> {

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -1,5 +1,20 @@
 import { err, errWithCause } from 'pino-std-serializers';
 
+export const defaultOmitHeaderNames = [
+  'x-envoy-attempt-count',
+  'x-envoy-decorator-operation',
+  'x-envoy-expected-rq-timeout-ms',
+  'x-envoy-external-address',
+  'x-envoy-internal',
+  'x-envoy-peer-metadata',
+  'x-envoy-peer-metadata-id',
+  'x-envoy-upstream-service-time',
+];
+
+export interface SerializerOptions {
+  omitHeaderNames?: string[];
+}
+
 interface Socket {
   remoteAddress?: string;
   remotePort?: string;

--- a/src/serializers/omitProperties.test.ts
+++ b/src/serializers/omitProperties.test.ts
@@ -2,50 +2,35 @@ import { omitProperties } from './omitProperties';
 
 const omitPropertyNames = ['omit-prop', 'omit.prop', '', '0'];
 
-const objBase: Readonly<Record<string, unknown>> = {
-  keepProp: 'Some value',
-  ['omit-prop']: 'omit with dash',
-  ['omit.prop']: 'omit with dot',
-  ['']: 'omit with empty key',
-  ['0']: 'omit number as text key',
-  omit: { prop: 'DO NOT omit' },
-};
-
-it('omits list of keys from object', () => {
-  const result = omitProperties({ ...objBase }, omitPropertyNames);
-
-  expect(result).toStrictEqual({
+const createInput = (): Readonly<Record<string, unknown>> =>
+  Object.freeze({
     keepProp: 'Some value',
+    ['omit-prop']: 'omit with dash',
+    ['omit.prop']: 'omit with dot',
+    ['']: 'omit with empty key',
+    ['0']: 'omit number as text key',
     omit: { prop: 'DO NOT omit' },
   });
-});
 
-it.each`
-  scenario        | keyName
-  ${'undefined'}  | ${undefined}
-  ${'null'}       | ${null}
-  ${'non-string'} | ${99}
-`('ignores $scenario key name', ({ keyName }) => {
-  const result = omitProperties(
-    {
-      ['99']: 'Keep key with number as text when same number provided as key',
-      ...objBase,
-    },
-    [...omitPropertyNames, keyName],
-  );
+it('omits list of keys from object', () => {
+  const input = createInput();
+
+  const result = omitProperties(input, omitPropertyNames);
 
   expect(result).toStrictEqual({
-    ['99']: 'Keep key with number as text when same number provided as key',
     keepProp: 'Some value',
     omit: { prop: 'DO NOT omit' },
   });
 });
 
 it('does not alter input object', () => {
-  const obj = { ...objBase };
-  omitProperties({ ...objBase }, omitPropertyNames);
+  const input = createInput();
 
-  expect(obj).toStrictEqual(objBase);
+  const originalInput = structuredClone(input);
+
+  omitProperties(input, omitPropertyNames);
+
+  expect(input).toEqual(originalInput);
 });
 
 it.each`

--- a/src/serializers/omitProperties.test.ts
+++ b/src/serializers/omitProperties.test.ts
@@ -1,0 +1,62 @@
+import { omitProperties } from './omitProperties';
+
+const omitPropertyNames = ['omit-prop', 'omit.prop', '', '0'];
+
+const objBase: Readonly<Record<string, unknown>> = {
+  keepProp: 'Some value',
+  ['omit-prop']: 'omit with dash',
+  ['omit.prop']: 'omit with dot',
+  ['']: 'omit with empty key',
+  ['0']: 'omit number as text key',
+  omit: { prop: 'DO NOT omit' },
+};
+
+it('omits list of keys from object', () => {
+  const result = omitProperties({ ...objBase }, omitPropertyNames);
+
+  expect(result).toStrictEqual({
+    keepProp: 'Some value',
+    omit: { prop: 'DO NOT omit' },
+  });
+});
+
+it.each`
+  scenario        | keyName
+  ${'undefined'}  | ${undefined}
+  ${'null'}       | ${null}
+  ${'non-string'} | ${99}
+`('ignores $scenario key name', ({ keyName }) => {
+  const result = omitProperties(
+    {
+      ['99']: 'Keep key with number as text when same number provided as key',
+      ...objBase,
+    },
+    [...omitPropertyNames, keyName],
+  );
+
+  expect(result).toStrictEqual({
+    ['99']: 'Keep key with number as text when same number provided as key',
+    keepProp: 'Some value',
+    omit: { prop: 'DO NOT omit' },
+  });
+});
+
+it('does not alter input object', () => {
+  const obj = { ...objBase };
+  omitProperties({ ...objBase }, omitPropertyNames);
+
+  expect(obj).toStrictEqual(objBase);
+});
+
+it.each`
+  scenario             | input
+  ${'undefined'}       | ${undefined}
+  ${'null'}            | ${null}
+  ${'an empty object'} | ${{}}
+  ${'not an object'}   | ${'key1=value1,key2=value2'}
+  ${'an array'}        | ${[{ key1: 'value1' }, { key2: 'value2' }]}
+`('returns input when it is $scenario', ({ input }) => {
+  const result = omitProperties(input, omitPropertyNames);
+
+  expect(result).toStrictEqual(input);
+});

--- a/src/serializers/omitProperties.ts
+++ b/src/serializers/omitProperties.ts
@@ -1,23 +1,20 @@
 export const omitProperties = (
-  record: Record<string, unknown>,
-  keyList: string[],
-): Record<string, unknown> => {
-  if (!record || typeof record !== 'object' || Array.isArray(record))
-    return record;
-
-  let reducedRecord = record;
-
-  /* eslint-disable-next-line @typescript-eslint/prefer-for-of --
-   * For loop is faster than `for of` and performance is preferred over readability here
-   **/
-  for (let keyIndex = 0; keyIndex < keyList.length; keyIndex++) {
-    const key = keyList[keyIndex];
-    if (typeof key !== 'string') continue;
-
-    const { [key]: _, ...keepRecord } = reducedRecord;
-
-    reducedRecord = keepRecord;
+  input: unknown,
+  properties: string[],
+): unknown => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
   }
 
-  return reducedRecord;
+  // We can get away with a shallow clone as we only touch top-level properties.
+  const output: Record<PropertyKey, unknown> = {
+    ...input,
+  };
+
+  for (const property of properties) {
+    // Remove the property from our shallow clone.
+    delete output[property];
+  }
+
+  return output;
 };

--- a/src/serializers/omitProperties.ts
+++ b/src/serializers/omitProperties.ts
@@ -1,0 +1,23 @@
+export const omitProperties = (
+  record: Record<string, unknown>,
+  keyList: string[],
+): Record<string, unknown> => {
+  if (!record || typeof record !== 'object' || Array.isArray(record))
+    return record;
+
+  let reducedRecord = record;
+
+  /* eslint-disable-next-line @typescript-eslint/prefer-for-of --
+   * For loop is faster than `for of` and performance is preferred over readability here
+   **/
+  for (let keyIndex = 0; keyIndex < keyList.length; keyIndex++) {
+    const key = keyList[keyIndex];
+    if (typeof key !== 'string') continue;
+
+    const { [key]: _, ...keepRecord } = reducedRecord;
+
+    reducedRecord = keepRecord;
+  }
+
+  return reducedRecord;
+};

--- a/src/serializers/omitPropertiesSerializer.test.ts
+++ b/src/serializers/omitPropertiesSerializer.test.ts
@@ -9,21 +9,6 @@ import { createOmitPropertiesSerializer } from './omitPropertiesSerializer';
 const omitPropertyNamesBase = ['remove-prop', 'remove.prop'];
 
 it.each`
-  scenario       | topLevelPropertyName
-  ${'undefined'} | ${undefined}
-  ${'null'}      | ${null}
-`(
-  'returns empty object when topLevelPropertyName is $scenario',
-  ({ topLevelPropertyName }) => {
-    const serializer = createOmitPropertiesSerializer(topLevelPropertyName, {
-      omitPropertyNames: [...omitPropertyNamesBase],
-    });
-
-    expect(serializer).toStrictEqual({});
-  },
-);
-
-it.each`
   scenario                  | omitPropertyNames
   ${'undefined'}            | ${undefined}
   ${'null'}                 | ${null}
@@ -32,20 +17,16 @@ it.each`
 `(
   'returns empty object when omitPropertyNames is $scenario',
   ({ omitPropertyNames }) => {
-    const serializer = createOmitPropertiesSerializer('main', {
-      omitPropertyNames,
-    });
+    const serializer = createOmitPropertiesSerializer(omitPropertyNames);
 
-    expect(serializer).toStrictEqual({});
+    expect(serializer({})).toStrictEqual({});
   },
 );
 
 it('returns object with named property containing function', () => {
-  const serializer = createOmitPropertiesSerializer('main', {
-    omitPropertyNames: [...omitPropertyNamesBase],
-  });
+  const serializer = createOmitPropertiesSerializer(omitPropertyNamesBase);
 
-  expect(serializer).toStrictEqual({ main: expect.any(Function) });
+  expect(serializer).toStrictEqual(expect.any(Function));
 });
 
 const sink = () =>
@@ -71,9 +52,7 @@ function once(emitter: Transform, name: string) {
 }
 
 it('omits properties from logged object', async () => {
-  const serializer = createOmitPropertiesSerializer('main', {
-    omitPropertyNames: [...omitPropertyNamesBase],
-  });
+  const serializer = createOmitPropertiesSerializer(omitPropertyNamesBase);
 
   const input = {
     main: {
@@ -112,9 +91,7 @@ it.each`
 `(
   'does nothing when top-level property is $scenario',
   async ({ value, expected }) => {
-    const serializer = createOmitPropertiesSerializer('main', {
-      omitPropertyNames: ['keepProp'],
-    });
+    const serializer = createOmitPropertiesSerializer(['keepProp']);
 
     const input = {
       main: value,

--- a/src/serializers/omitPropertiesSerializer.test.ts
+++ b/src/serializers/omitPropertiesSerializer.test.ts
@@ -1,0 +1,136 @@
+import type { Transform } from 'stream';
+
+import split from 'split2';
+
+import createLogger from '..';
+
+import { createOmitPropertiesSerializer } from './omitPropertiesSerializer';
+
+const omitPropertyNamesBase = ['remove-prop', 'remove.prop'];
+
+it.each`
+  scenario       | topLevelPropertyName
+  ${'undefined'} | ${undefined}
+  ${'null'}      | ${null}
+`(
+  'returns empty object when topLevelPropertyName is $scenario',
+  ({ topLevelPropertyName }) => {
+    const serializer = createOmitPropertiesSerializer(topLevelPropertyName, {
+      omitPropertyNames: [...omitPropertyNamesBase],
+    });
+
+    expect(serializer).toStrictEqual({});
+  },
+);
+
+it.each`
+  scenario                  | omitPropertyNames
+  ${'undefined'}            | ${undefined}
+  ${'null'}                 | ${null}
+  ${'empty'}                | ${[]}
+  ${'list without strings'} | ${[undefined, null, 1, true, false, {}, []]}
+`(
+  'returns empty object when omitPropertyNames is $scenario',
+  ({ omitPropertyNames }) => {
+    const serializer = createOmitPropertiesSerializer('main', {
+      omitPropertyNames,
+    });
+
+    expect(serializer).toStrictEqual({});
+  },
+);
+
+it('returns object with named property containing function', () => {
+  const serializer = createOmitPropertiesSerializer('main', {
+    omitPropertyNames: [...omitPropertyNamesBase],
+  });
+
+  expect(serializer).toStrictEqual({ main: expect.any(Function) });
+});
+
+const sink = () =>
+  split((data) => {
+    try {
+      return JSON.parse(data);
+    } catch (err) {
+      console.log(err); // eslint-disable-line
+      console.log(data); // eslint-disable-line
+    }
+  });
+
+function once(emitter: Transform, name: string) {
+  return new Promise((resolve, reject) => {
+    if (name !== 'error') {
+      emitter.once('error', reject);
+    }
+    emitter.once(name, (arg: unknown) => {
+      emitter.removeListener('error', reject);
+      resolve(arg);
+    });
+  });
+}
+
+it('omits properties from logged object', async () => {
+  const serializer = createOmitPropertiesSerializer('main', {
+    omitPropertyNames: [...omitPropertyNamesBase],
+  });
+
+  const input = {
+    main: {
+      keepProp: 'Some value',
+      ['remove-prop']: 'remove with dash',
+      ['remove.prop']: 'remove with dot',
+      remove: { prop: 'DO NOT REMOVE' },
+    },
+  };
+
+  const inputString = JSON.stringify(input);
+  const stream = sink();
+  const logger = createLogger(
+    { name: 'my-app', serializers: { ...serializer } },
+    stream,
+  );
+  logger.info(input);
+
+  const log: any = await once(stream, 'data');
+  expect(log).toMatchObject({
+    main: {
+      keepProp: 'Some value',
+      remove: { prop: 'DO NOT REMOVE' },
+    },
+  });
+  expect(inputString).toEqual(JSON.stringify(input));
+  expect(log).toHaveProperty('timestamp');
+});
+
+it.each`
+  scenario           | value               | expected
+  ${'undefined'}     | ${undefined}        | ${{}}
+  ${'null'}          | ${null}             | ${{ main: null }}
+  ${'not an object'} | ${123}              | ${{ main: 123 }}
+  ${'an array'}      | ${[{ value: 123 }]} | ${{ main: [{ value: 123 }] }}
+`(
+  'does nothing when top-level property is $scenario',
+  async ({ value, expected }) => {
+    const serializer = createOmitPropertiesSerializer('main', {
+      omitPropertyNames: ['keepProp'],
+    });
+
+    const input = {
+      main: value,
+    };
+
+    const inputString = JSON.stringify(input);
+    const stream = sink();
+    const logger = createLogger(
+      { name: 'my-app', serializers: { ...serializer } },
+      stream,
+    );
+    logger.info(input);
+
+    const log: any = await once(stream, 'data');
+    expect(log).toMatchObject(expected);
+    expect(inputString).toEqual(JSON.stringify(input));
+    expect(log).toHaveProperty('timestamp');
+  },
+);

--- a/src/serializers/omitPropertiesSerializer.ts
+++ b/src/serializers/omitPropertiesSerializer.ts
@@ -1,38 +1,19 @@
 import { omitProperties } from './omitProperties';
+import type { SerializerFn } from './types';
 
-export interface OmitPropertiesSerializerOptions {
+export const createOmitPropertiesSerializer = (
   /**
    * A list of properties that should not be logged.
    */
-  omitPropertyNames: string[];
-}
+  properties: string[],
+): SerializerFn => {
+  const uniquePropertySet = new Set(properties);
 
-type OmitHeaderNamesFn = (record: unknown) => unknown;
-type OmitHeaderNamesSerializer = Record<string, OmitHeaderNamesFn>;
-
-/** Creates a serializer that operates on the logged object's top-level property named `topLevelPropertyName`
- *  and omits the properties listed in `options.omitPropertyNames`.
- *  @param topLevelPropertyName - The name of the root property on the logged object that to omit properties from.
- *  @param options - Options for the serializer.
- */
-export const createOmitPropertiesSerializer = (
-  topLevelPropertyName: string,
-  options: OmitPropertiesSerializerOptions,
-): OmitHeaderNamesSerializer => {
-  const propertyNames = [...new Set(options.omitPropertyNames ?? [])].filter(
-    (propertyName) => typeof propertyName === 'string',
-  );
-
-  if (
-    !topLevelPropertyName ||
-    typeof topLevelPropertyName !== 'string' ||
-    topLevelPropertyName.length === 0 ||
-    propertyNames.length === 0
-  ) {
-    return {};
+  if (uniquePropertySet.size === 0) {
+    return (input) => input;
   }
 
-  return {
-    [topLevelPropertyName]: (record) => omitProperties(record, propertyNames),
-  };
+  const uniqueProperties = Array.from(uniquePropertySet);
+
+  return (input) => omitProperties(input, uniqueProperties);
 };

--- a/src/serializers/omitPropertiesSerializer.ts
+++ b/src/serializers/omitPropertiesSerializer.ts
@@ -7,9 +7,7 @@ export interface OmitPropertiesSerializerOptions {
   omitPropertyNames: string[];
 }
 
-type OmitHeaderNamesFn = (
-  record: Record<string, unknown>,
-) => Record<string, unknown>;
+type OmitHeaderNamesFn = (record: unknown) => unknown;
 type OmitHeaderNamesSerializer = Record<string, OmitHeaderNamesFn>;
 
 /** Creates a serializer that operates on the logged object's top-level property named `topLevelPropertyName`
@@ -35,7 +33,6 @@ export const createOmitPropertiesSerializer = (
   }
 
   return {
-    [topLevelPropertyName]: (record: Record<string, unknown>) =>
-      omitProperties(record, propertyNames),
+    [topLevelPropertyName]: (record) => omitProperties(record, propertyNames),
   };
 };

--- a/src/serializers/omitPropertiesSerializer.ts
+++ b/src/serializers/omitPropertiesSerializer.ts
@@ -1,0 +1,41 @@
+import { omitProperties } from './omitProperties';
+
+export interface OmitPropertiesSerializerOptions {
+  /**
+   * A list of properties that should not be logged.
+   */
+  omitPropertyNames: string[];
+}
+
+type OmitHeaderNamesFn = (
+  record: Record<string, unknown>,
+) => Record<string, unknown>;
+type OmitHeaderNamesSerializer = Record<string, OmitHeaderNamesFn>;
+
+/** Creates a serializer that operates on the logged object's top-level property named `topLevelPropertyName`
+ *  and omits the properties listed in `options.omitPropertyNames`.
+ *  @param topLevelPropertyName - The name of the root property on the logged object that to omit properties from.
+ *  @param options - Options for the serializer.
+ */
+export const createOmitPropertiesSerializer = (
+  topLevelPropertyName: string,
+  options: OmitPropertiesSerializerOptions,
+): OmitHeaderNamesSerializer => {
+  const propertyNames = [...new Set(options.omitPropertyNames ?? [])].filter(
+    (propertyName) => typeof propertyName === 'string',
+  );
+
+  if (
+    !topLevelPropertyName ||
+    typeof topLevelPropertyName !== 'string' ||
+    topLevelPropertyName.length === 0 ||
+    propertyNames.length === 0
+  ) {
+    return {};
+  }
+
+  return {
+    [topLevelPropertyName]: (record: Record<string, unknown>) =>
+      omitProperties(record, propertyNames),
+  };
+};

--- a/src/serializers/types.ts
+++ b/src/serializers/types.ts
@@ -1,0 +1,1 @@
+export type SerializerFn = (input: unknown) => unknown;


### PR DESCRIPTION
## Purpose

Alternative to https://github.com/seek-oss/logger/pull/84

Pino has a limitation where you can either redact or remove specified redact.paths by setting redact.remove to true or false.

In some cases, it's reasonable to want to redact some properties e.g. headers.authorization so you know that you have an authorization header but in other cases, the header, e.g. x-envoy-peer-metadata only contributes to increasing the log message size and therefore cost.

To reduce costs, we should be able to remove the properties that are not relevant for diagnostic purposes.

## Approach

- Properties containing headers that should be omitted were identified via this Splunk query over 1 business day:

  ```splunkspl
  index="*" 
  | fields *x-envoy-*
  | fieldsummary
  | rex mode=sed field=values "s~\[?\{\"value\":\"~~g
    s~\",\"count\":\d+\}[,\]]*~~g"
  | eval avgBytes=round(len(values)/distinct_count,0), totalMiB=avgBytes*count/1024/1024
  | table field, count, distinct_count, avgBytes, totalMiB
  | sort 0 -totalMiB
  ```

  - The headers are typically under `req`, `headers`, and `requestHeader` properties.

- Added `defaultOmitHeaderNames` which is a list of header names to omit.

  ```typescript
  export const defaultOmitHeaderNames = [
    'x-envoy-attempt-count',
    'x-envoy-decorator-operation',
    'x-envoy-expected-rq-timeout-ms',
    'x-envoy-external-address',
    'x-envoy-internal',
    'x-envoy-peer-metadata',
    'x-envoy-peer-metadata-id',
  ];
  ```

- Add a `omitHeaderNames` logger option that defaults to the `defaultOmitHeaderNames`. If a consumer wants to opt out, they can supply an empty list or their own list instead.

- A `headers` custom serializer omits the specified headers from the `headers` property of the logged object.

- The existing `req` custom serializer also omits the specified headers from the `req.headers` property of the logged object.

## Notes

💡 It may be helpful to review commit-by-commit.

_Answers from discussion with @72636c_

1. ✅ What's the risk classification for this change since it affects much of SEEK?  
   _`Minimal Risk` based on this being "...business critical given it ladders up to a citizenship ask (cost savings), has limited risk (only removes headers from logs that you’ve de-risked, pending point 3), and it’s still up to individual team discretion to review & choose to merge the version bump"._
2. ✅ There is no `reqHeaders` custom serializer so some guidance around this is needed. We could add this as it would be a clone of the `headers` custom serializer.  
   _Since `reqHeaders` is produced by two services of one team, we will not be adding a specific custom serializer._
3. ✅ Still following up with cloud platform team on these headers.
   _Cloud platform team is ok with this change and has had a look at this PR._
4. ✅ Is it ok to remove the default export from `serializers` since it isn't used internally and I don't think it's accessible via e.g. `import serializers from '@seek/logger/lib-commonjs/serializers'`. 
   _Removed default export from serializers._

## Issues

Relates to https://github.com/seek-oss/logger/issues/83 but does not resolve it.

