### PR TITLE
Use `toStrictEqual` in root tests

### DIFF
--- a/.changeset/moody-bobcats-travel.md
+++ b/.changeset/moody-bobcats-travel.md
@@ -15,7 +15,7 @@ Omit request headers
 - `x-envoy-peer-metadata-id`
 - `x-envoy-upstream-service-time`
 
-If you would like to opt out of this behaviours, you can provide an empty list or your own list of request headers to `omitHeaderNames`:
+To opt out of this behaviour, provide an empty list or your own list of omissible request headers to `omitHeaderNames`:
 
 ```diff
 const logger = createLogger({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -54,7 +54,6 @@ function testLog(
       ...output,
     });
     expect(inputString).toEqual(JSON.stringify(input));
-    expect(log).toHaveProperty('timestamp');
   });
 }
 


### PR DESCRIPTION
`toMatchObject` accepts an object subset, which makes it hard to reliably test property removal. For example, #92 adds a happy-path test case "should omit defaultOmitHeaderNames by default" which unexpectedly passes even if the omission logic is removed.

These tests aren't great overall and I'd prefer them to use a more typical Jest structure so we can use `.only`s and the like, but this should be enough to get #92 through with confidence around regression testing.