### PR TITLE
Freeze `DEFAULT_OMIT_HEADER_NAMES`

### DIFF
--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -2,6 +2,29 @@ import { DEFAULT_OMIT_HEADER_NAMES, createSerializers } from '.';
 
 const serializers = createSerializers({});
 
+describe('DEFAULT_OMIT_HEADER_NAMES', () => {
+  it('disallows mutation', () => {
+    const firstElement = DEFAULT_OMIT_HEADER_NAMES[0];
+
+    expect(() => {
+      // @ts-expect-error - We're trying to break the read-only array (TS2542).
+      DEFAULT_OMIT_HEADER_NAMES[0] = 'badness!';
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot assign to read only property '0' of object '[object Array]'"`,
+    );
+
+    expect(() => {
+      // @ts-expect-error - We're trying to break the read-only array (TS2542).
+      delete DEFAULT_OMIT_HEADER_NAMES[0];
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot delete property '0' of [object Array]"`,
+    );
+
+    // Assignment didn't take effect!
+    expect(DEFAULT_OMIT_HEADER_NAMES[0]).toBe(firstElement);
+  });
+});
+
 describe('req', () => {
   const remoteAddress = '::ffff:123.45.67.89';
   const remotePort = 12345;

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -28,7 +28,7 @@ export interface SerializerOptions {
    * Defaults to `DEFAULT_OMIT_HEADER_NAMES`,
    * and can be disabled by supplying an empty array `[]`.
    */
-  omitHeaderNames?: string[];
+  omitHeaderNames?: readonly string[];
 }
 
 interface Socket {

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -4,7 +4,7 @@ import { err, errWithCause } from 'pino-std-serializers';
 import { createOmitPropertiesSerializer } from './omitPropertiesSerializer';
 import type { SerializerFn } from './types';
 
-export const DEFAULT_OMIT_HEADER_NAMES = [
+export const DEFAULT_OMIT_HEADER_NAMES = Object.freeze([
   'x-envoy-attempt-count',
   'x-envoy-decorator-operation',
   'x-envoy-expected-rq-timeout-ms',
@@ -13,7 +13,7 @@ export const DEFAULT_OMIT_HEADER_NAMES = [
   'x-envoy-peer-metadata',
   'x-envoy-peer-metadata-id',
   'x-envoy-upstream-service-time',
-];
+]);
 
 export interface SerializerOptions {
   /**

--- a/src/serializers/omitPropertiesSerializer.ts
+++ b/src/serializers/omitPropertiesSerializer.ts
@@ -5,7 +5,7 @@ export const createOmitPropertiesSerializer = (
   /**
    * A list of properties that should not be logged.
    */
-  properties: string[],
+  properties: readonly string[],
 ): SerializerFn => {
   const uniquePropertySet = new Set(properties);
 


### PR DESCRIPTION
We don't want consumers to unintentionally mutate this constant.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze