### PR TITLE
deps: dtrim ^1.11.2

### DIFF
--- a/.changeset/gorgeous-lies-work.md
+++ b/.changeset/gorgeous-lies-work.md
@@ -1,0 +1,7 @@
+---
+'@seek/logger': patch
+---
+
+deps: dtrim ^1.11.2
+
+This propagates the [removal](https://github.com/runk/dtrim/releases/tag/v1.11.1) of a transient `inflight` dependency. Resolves [SNYK-JS-INFLIGHT-6095116](https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116).

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:ci": "skuba test --coverage"
   },
   "dependencies": {
-    "dtrim": "^1.11.0",
+    "dtrim": "^1.11.2",
     "pino": "^8.0.0",
     "pino-std-serializers": "^6.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,7 +3119,7 @@ dotenv@^16.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
-dtrim@^1.11.0:
+dtrim@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/dtrim/-/dtrim-1.11.2.tgz#6bf460474fbc981f5ad8f0b7263b61f9dd638cdc"
   integrity sha512-i6Q3s/KUEaybdjwIj2H5HdEUai/nhz/lfM4k1BqJj1T4nyNvuTmdfle7tIsVBkZayXiK8VlLMJYz1+ckQJqxrA==


### PR DESCRIPTION
This should propagate the removal of the vulnerable `inflight` package to consumers. **Alternatively, we could leave it up to consumers to relock their dependencies; open to opinions here.**

- https://github.com/runk/dtrim/releases/tag/v1.11.1
- https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116