### PR TITLE
fix: Merge default redact paths with custom redact paths

### DIFF
--- a/.changeset/healthy-pans-joke.md
+++ b/.changeset/healthy-pans-joke.md
@@ -1,0 +1,12 @@
+---
+'@seek/logger': major
+---
+
+fix: Merging default redact paths with custom redact options
+
+Default redact paths were added.
+
+Tests revealed that creating the logger with a custom redact options object
+instead of an array of strings would override the default redact paths.
+
+This change concatenates the default redact paths and the custom `redact.paths`.

--- a/.changeset/healthy-pans-joke.md
+++ b/.changeset/healthy-pans-joke.md
@@ -2,11 +2,8 @@
 '@seek/logger': major
 ---
 
-fix: Merging default redact paths with custom redact options
+Add default redact paths
 
-Default redact paths were added.
+`@seek/logger` now redacts a set of [built-in paths](https://github.com/seek-oss/logger/blob/add-default-header-redacts/src/redact/index.ts) by default.
 
-Tests revealed that creating the logger with a custom redact options object
-instead of an array of strings would override the default redact paths.
-
-This change concatenates the default redact paths and the custom `redact.paths`.
+These default paths cannot be disabled, and are concatenated to custom redact paths provided via `redact: ['custom.path']` or `redact: { paths: ['custom.path'] }`.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ logger.error<Fields>(
 
 Bearer tokens are redacted regardless of their placement in the log object.
 
+Some property paths are redacted by default. See `defaultRedact` in
+[src/redact/index.ts](src/redact/index.ts) for the path list.
+
 Additional property paths can be redacted using the `redact` logger option as per
 [pino redaction].
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -319,6 +319,24 @@ testLog(
 );
 
 testLog(
+  'should redact default paths in object when custom redact options are provided',
+  {
+    header: { 'user-email': 'user_test@test.com' },
+    headers: { 'user-email': 'user_test@test.com' },
+    req: { headers: { 'user-email': 'user_test@test.com' } },
+    data: { auth: 'secret' },
+  },
+  {
+    header: { 'user-email': '[Redacted 🙈]' },
+    headers: { 'user-email': '[Redacted 🙈]' },
+    req: { headers: { 'user-email': '[Redacted 🙈]' } },
+    data: { auth: '[Redacted 🙈]' },
+  },
+  undefined,
+  { redact: { paths: ['data.auth'], censor: '[Redacted 🙈]' } },
+);
+
+testLog(
   'should handle redaction path at max object depth + 1',
   {
     a: { b: [{ name: 'Bob' }] },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -286,6 +286,39 @@ testLog(
 );
 
 testLog(
+  'should redact default paths in object',
+  {
+    header: { 'user-email': 'user_test@test.com' },
+    headers: { 'user-email': 'user_test@test.com' },
+    req: { headers: { 'user-email': 'user_test@test.com' } },
+  },
+  {
+    header: { 'user-email': '[Redacted]' },
+    headers: { 'user-email': '[Redacted]' },
+    req: { headers: { 'user-email': '[Redacted]' } },
+  },
+  undefined,
+);
+
+testLog(
+  'should redact default paths in object when custom redact paths are provided',
+  {
+    header: { 'user-email': 'user_test@test.com' },
+    headers: { 'user-email': 'user_test@test.com' },
+    req: { headers: { 'user-email': 'user_test@test.com' } },
+    data: { auth: 'secret' },
+  },
+  {
+    header: { 'user-email': '[Redacted]' },
+    headers: { 'user-email': '[Redacted]' },
+    req: { headers: { 'user-email': '[Redacted]' } },
+    data: { auth: '[Redacted]' },
+  },
+  undefined,
+  { redact: ['data.auth'] },
+);
+
+testLog(
   'should handle redaction path at max object depth + 1',
   {
     a: { b: [{ name: 'Bob' }] },

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -23,5 +23,5 @@ export const addDefaultRedactPathStrings = (
   if (Array.isArray(redact)) {
     return redact.concat(defaultRedact);
   }
-  return redact;
+  return { ...redact, paths: [...defaultRedact, ...redact.paths] };
 };

--- a/src/redact/index.ts
+++ b/src/redact/index.ts
@@ -1,5 +1,9 @@
 // TODO: Redact cookies?
-export const defaultRedact = [];
+export const defaultRedact = [
+  "header['user-email']",
+  "headers['user-email']",
+  "req.headers['user-email']",
+];
 
 /**
  * Private interface vendored from `pino`


### PR DESCRIPTION
## Purpose

The following paths must be redacted due to their content:

- `header['user-email']`
- `headers['user-email']`
- `req.headers['user-email']`

## Approach

- Adds the paths to `defaultRedact` in `src/redact/index.ts`.
- Adds tests to assert default redact paths are always redacted.
- Fixes issue where default redact paths were not redacted when an object was provided as the `redact` options.
