### PR TITLE
Trim objects that are serialized by `err` and `errWithCause`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -641,18 +641,8 @@ class Req {
   }
 }
 testLog(
-  'should not truncate objects with a serializer',
+  'should not truncate objects with a non error serializer',
   {
-    errWithCause: {
-      a: {
-        b: {},
-      },
-    },
-    err: {
-      a: {
-        b: {},
-      },
-    },
     req: new Req(),
     notSerialized: {
       a: {
@@ -661,16 +651,6 @@ testLog(
     },
   },
   {
-    errWithCause: {
-      a: {
-        b: {},
-      },
-    },
-    err: {
-      a: {
-        b: {},
-      },
-    },
     req: {
       remoteAddress: 'localhost',
       remotePort: '4000',
@@ -682,6 +662,66 @@ testLog(
   'info',
   {
     maxObjectDepth: 2,
+  },
+);
+
+testLog(
+  'should truncate objects with error serializers',
+  {
+    errWithCause: {
+      a: {
+        b: {},
+      },
+    },
+    err: {
+      a: {
+        b: {},
+      },
+    },
+  },
+  {
+    errWithCause: {
+      a: {
+        b: '[Object]',
+      },
+    },
+    err: {
+      a: {
+        b: '[Object]',
+      },
+    },
+  },
+  'info',
+  {
+    maxObjectDepth: 2,
+  },
+);
+
+testLog(
+  'should truncate strings longer than 512 characters with error serializers',
+  {
+    err: {
+      anyField: {
+        anyField: 'a'.repeat(555),
+      },
+    },
+    errWithCause: {
+      anyField: {
+        anyField: 'a'.repeat(555),
+      },
+    },
+  },
+  {
+    err: {
+      anyField: {
+        anyField: `${'a'.repeat(512)}...`,
+      },
+    },
+    errWithCause: {
+      anyField: {
+        anyField: `${'a'.repeat(512)}...`,
+      },
+    },
   },
 );
 


### PR DESCRIPTION
## Purpose

This [test](https://github.com/seek-oss/logger/blob/26f7f5409c53d295c7932a50952c587b184570a7/src/index.test.ts#L700-L726) fails in master with the following output, which can result in some quite nasty logs... I caught this in a few logs that were logging entire html documents 🫠 

![image](https://github.com/user-attachments/assets/87b05016-984c-4f98-99a7-6dffe3b94a51)


## Approach

Trim the returned objected from both the [err](https://github.com/pinojs/pino-std-serializers/blob/dc2ce14ebb9497d2ebe1a37c9f0da8d711ef5cc0/lib/err.js) and [errWithCause](https://github.com/pinojs/pino-std-serializers/blob/dc2ce14ebb9497d2ebe1a37c9f0da8d711ef5cc0/lib/err-with-cause.js#L47) serializers with the desired formatting options. 
