### PR TITLE
Add truncation to all serializers

### DIFF
--- a/.changeset/smooth-ties-look.md
+++ b/.changeset/smooth-ties-look.md
@@ -1,0 +1,5 @@
+---
+'@seek/logger': major
+---
+
+Adds trimming to log fields with dedicated serializers

--- a/.changeset/smooth-ties-look.md
+++ b/.changeset/smooth-ties-look.md
@@ -2,4 +2,8 @@
 '@seek/logger': major
 ---
 
-Adds trimming to log fields with dedicated serializers
+Apply trimming to serializers
+
+Previously, [built-in serializers](https://github.com/seek-oss/logger/tree/54f16e17a9bb94261b9d2e4b77f04f55d5a3ab4c?tab=readme-ov-file#standardised-fields) and custom ones supplied via the [`serializers` option](https://github.com/pinojs/pino/blob/8aafa88139890b97aca0d32601cb5ffdd9bda1eb/docs/api.md#serializers-object) were not subject to [trimming](https://github.com/seek-oss/logger/tree/54f16e17a9bb94261b9d2e4b77f04f55d5a3ab4c?tab=readme-ov-file#trimming). This caused some emitted error logs to be extremely large.
+
+Now, trimming is applied across all serializers by default. If you rely on deeply nested `err` properties to troubleshoot your application, tune the `maxObjectDepth` configured on your logger.

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -1,6 +1,8 @@
 import { trimmer } from 'dtrim';
 import type { LoggerOptions } from 'pino';
 
+export const DEFAULT_MAX_OBJECT_DEPTH = 4;
+
 export interface FormatterOptions {
   /**
    * Maximum property depth of objects being logged. Default: 4
@@ -17,7 +19,7 @@ export const createFormatters = (
   opts: FormatterOptions & Required<Pick<LoggerOptions, 'serializers'>>,
 ): LoggerOptions['formatters'] => {
   const trim = trimmer({
-    depth: opts.maxObjectDepth ?? 4,
+    depth: opts.maxObjectDepth ?? DEFAULT_MAX_OBJECT_DEPTH,
     retain: new Set(Object.keys(opts.serializers)),
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -441,10 +441,7 @@ testLog(
       request: {
         _options: {
           method: 'get',
-          headers: {
-            Accept: 'application/json, text/plain, */*',
-            authorization: '[Redacted]',
-          },
+          headers: '[Object]',
         },
         domain: null,
       },
@@ -633,7 +630,7 @@ test('should log customized timestamp if timestamp logger option is supplied', a
 });
 
 testLog(
-  'should truncate objects with serializers',
+  'should trim default serializers',
   {
     errWithCause: {
       a: {
@@ -698,7 +695,36 @@ testLog(
   },
   'info',
   {
-    maxObjectDepth: 2,
+    maxObjectDepth: 3,
+  },
+);
+
+testLog(
+  'should trim custom serializer',
+  {
+    serialize: {
+      a: {
+        b: {
+          c: {},
+        },
+      },
+      anyField: 'a'.repeat(555),
+    },
+  },
+  {
+    serialize: {
+      a: {
+        b: '[Object]',
+      },
+      anyField: `${'a'.repeat(512)}...`,
+    },
+  },
+  'info',
+  {
+    serializers: {
+      serialize: (input: unknown) => input,
+    },
+    maxObjectDepth: 3,
   },
 );
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -637,12 +637,14 @@ testLog(
         b: {},
       },
       anyField: 'a'.repeat(555),
+      stack: 'a'.repeat(555),
     },
     err: {
       a: {
         b: {},
       },
       anyField: 'a'.repeat(555),
+      stack: 'a'.repeat(555),
     },
     req: {
       method: 'GET',
@@ -668,12 +670,14 @@ testLog(
         b: '[Object]',
       },
       anyField: `${'a'.repeat(512)}...`,
+      stack: 'a'.repeat(555),
     },
     err: {
       a: {
         b: '[Object]',
       },
       anyField: `${'a'.repeat(512)}...`,
+      stack: 'a'.repeat(555),
     },
     req: {
       method: 'GET',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -632,60 +632,65 @@ test('should log customized timestamp if timestamp logger option is supplied', a
   expect(log.timestamp).toBe(mockTimestamp);
 });
 
-class Req {
-  get socket() {
-    return {
-      remoteAddress: 'localhost',
-      remotePort: '4000',
-    };
-  }
-}
 testLog(
-  'should not truncate objects with a non error serializer',
+  'should truncate objects with serializers',
   {
-    req: new Req(),
-    notSerialized: {
+    errWithCause: {
       a: {
         b: {},
       },
+      anyField: 'a'.repeat(555),
     },
-  },
-  {
+    err: {
+      a: {
+        b: {},
+      },
+      anyField: 'a'.repeat(555),
+    },
     req: {
+      method: 'GET',
+      url: 'a'.repeat(555),
+      headers: [],
+      socket: { remoteAddress: 'localhost', remotePort: '4000' },
+    },
+    res: {
+      headers: { Origin: 'a'.repeat(555) },
+      status: 500,
+      foo: 'baz',
+    },
+    headers: {
+      'test-header': 'a'.repeat(555),
+      a: {
+        b: {},
+      },
+    },
+  },
+  {
+    errWithCause: {
+      a: {
+        b: '[Object]',
+      },
+      anyField: `${'a'.repeat(512)}...`,
+    },
+    err: {
+      a: {
+        b: '[Object]',
+      },
+      anyField: `${'a'.repeat(512)}...`,
+    },
+    req: {
+      method: 'GET',
+      url: `${'a'.repeat(512)}...`,
+      headers: [],
       remoteAddress: 'localhost',
       remotePort: '4000',
     },
-    notSerialized: {
-      a: '[Object]',
+    res: {
+      headers: { Origin: `${'a'.repeat(512)}...` },
+      statusCode: 500,
     },
-  },
-  'info',
-  {
-    maxObjectDepth: 2,
-  },
-);
-
-testLog(
-  'should truncate objects with error serializers',
-  {
-    errWithCause: {
-      a: {
-        b: {},
-      },
-    },
-    err: {
-      a: {
-        b: {},
-      },
-    },
-  },
-  {
-    errWithCause: {
-      a: {
-        b: '[Object]',
-      },
-    },
-    err: {
+    headers: {
+      'test-header': `${'a'.repeat(512)}...`,
       a: {
         b: '[Object]',
       },
@@ -694,34 +699,6 @@ testLog(
   'info',
   {
     maxObjectDepth: 2,
-  },
-);
-
-testLog(
-  'should truncate strings longer than 512 characters with error serializers',
-  {
-    err: {
-      anyField: {
-        anyField: 'a'.repeat(555),
-      },
-    },
-    errWithCause: {
-      anyField: {
-        anyField: 'a'.repeat(555),
-      },
-    },
-  },
-  {
-    err: {
-      anyField: {
-        anyField: `${'a'.repeat(512)}...`,
-      },
-    },
-    errWithCause: {
-      anyField: {
-        anyField: `${'a'.repeat(512)}...`,
-      },
-    },
   },
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,11 @@
-import { trimmer } from 'dtrim';
 import pino from 'pino';
 
 import base from './base';
 import { createDestination } from './destination/create';
 import { withRedaction } from './destination/redact';
-import {
-  DEFAULT_MAX_OBJECT_DEPTH,
-  type FormatterOptions,
-  createFormatters,
-} from './formatters';
+import { type FormatterOptions, createFormatters } from './formatters';
 import * as redact from './redact';
-import {
-  type SerializerOptions,
-  createSerializers,
-  trimSerializers,
-} from './serializers';
+import { type SerializerOptions, createSerializers } from './serializers';
 
 export { createDestination } from './destination/create';
 export { DEFAULT_OMIT_HEADER_NAMES } from './serializers';
@@ -38,18 +29,7 @@ export default (
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
 
-  const trim = trimmer({
-    depth: (opts.maxObjectDepth ?? DEFAULT_MAX_OBJECT_DEPTH) - 1,
-    retain: new Set(['stack']),
-  });
-
-  const serializers = trimSerializers(
-    {
-      ...createSerializers(opts),
-      ...opts.serializers,
-    },
-    trim,
-  );
+  const serializers = createSerializers(opts);
 
   opts.serializers = serializers;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export default (
 
   const trim = trimmer({
     depth: (opts.maxObjectDepth ?? DEFAULT_MAX_OBJECT_DEPTH) - 1,
+    retain: new Set(['stack']),
   });
 
   const serializers = trimSerializers(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import * as redact from './redact';
 import {
   type SerializerOptions,
   createSerializers,
-  trimCustomSerializers,
+  trimSerializers,
 } from './serializers';
 
 export { createDestination } from './destination/create';
@@ -42,10 +42,13 @@ export default (
     depth: (opts.maxObjectDepth ?? DEFAULT_MAX_OBJECT_DEPTH) - 1,
   });
 
-  const serializers = {
-    ...createSerializers(opts, trim),
-    ...trimCustomSerializers(opts.serializers, trim),
-  };
+  const serializers = trimSerializers(
+    {
+      ...createSerializers(opts),
+      ...opts.serializers,
+    },
+    trim,
+  );
 
   opts.serializers = serializers;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,20 @@
+import { trimmer } from 'dtrim';
 import pino from 'pino';
 
 import base from './base';
 import { createDestination } from './destination/create';
 import { withRedaction } from './destination/redact';
-import { type FormatterOptions, createFormatters } from './formatters';
+import {
+  DEFAULT_MAX_OBJECT_DEPTH,
+  type FormatterOptions,
+  createFormatters,
+} from './formatters';
 import * as redact from './redact';
-import { type SerializerOptions, createSerializers } from './serializers';
+import {
+  type SerializerOptions,
+  createSerializers,
+  trimCustomSerializers,
+} from './serializers';
 
 export { createDestination } from './destination/create';
 export { DEFAULT_OMIT_HEADER_NAMES } from './serializers';
@@ -29,9 +38,13 @@ export default (
 ): Logger => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
 
+  const trim = trimmer({
+    depth: (opts.maxObjectDepth ?? DEFAULT_MAX_OBJECT_DEPTH) - 1,
+  });
+
   const serializers = {
-    ...createSerializers(opts),
-    ...opts.serializers,
+    ...createSerializers(opts, trim),
+    ...trimCustomSerializers(opts.serializers, trim),
   };
 
   opts.serializers = serializers;

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -1,15 +1,6 @@
-import { trimmer } from 'dtrim';
-
-import { DEFAULT_MAX_OBJECT_DEPTH } from '../formatters';
-
 import { DEFAULT_OMIT_HEADER_NAMES, createSerializers } from '.';
 
-const serializers = createSerializers(
-  {},
-  trimmer({
-    depth: DEFAULT_MAX_OBJECT_DEPTH - 1,
-  }),
-);
+const serializers = createSerializers({});
 
 describe('DEFAULT_OMIT_HEADER_NAMES', () => {
   it('disallows mutation', () => {
@@ -159,12 +150,7 @@ describe('req', () => {
       },
     };
 
-    const altSerializers = createSerializers(
-      { omitHeaderNames: ['omit-me'] },
-      trimmer({
-        depth: DEFAULT_MAX_OBJECT_DEPTH - 1,
-      }),
-    );
+    const altSerializers = createSerializers({ omitHeaderNames: ['omit-me'] });
     const result = altSerializers.req(request);
 
     expect(result).toStrictEqual(expectedRequest);

--- a/src/serializers/index.test.ts
+++ b/src/serializers/index.test.ts
@@ -1,6 +1,15 @@
+import { trimmer } from 'dtrim';
+
+import { DEFAULT_MAX_OBJECT_DEPTH } from '../formatters';
+
 import { DEFAULT_OMIT_HEADER_NAMES, createSerializers } from '.';
 
-const serializers = createSerializers({});
+const serializers = createSerializers(
+  {},
+  trimmer({
+    depth: DEFAULT_MAX_OBJECT_DEPTH - 1,
+  }),
+);
 
 describe('DEFAULT_OMIT_HEADER_NAMES', () => {
   it('disallows mutation', () => {
@@ -150,7 +159,12 @@ describe('req', () => {
       },
     };
 
-    const altSerializers = createSerializers({ omitHeaderNames: ['omit-me'] });
+    const altSerializers = createSerializers(
+      { omitHeaderNames: ['omit-me'] },
+      trimmer({
+        depth: DEFAULT_MAX_OBJECT_DEPTH - 1,
+      }),
+    );
     const result = altSerializers.req(request);
 
     expect(result).toStrictEqual(expectedRequest);

--- a/src/serializers/omitPropertiesSerializer.ts
+++ b/src/serializers/omitPropertiesSerializer.ts
@@ -6,7 +6,7 @@ export const createOmitPropertiesSerializer = (
    * A list of properties that should not be logged.
    */
   properties: readonly string[],
-): SerializerFn => {
+): SerializerFn<unknown> => {
   const uniquePropertySet = new Set(properties);
 
   if (uniquePropertySet.size === 0) {

--- a/src/serializers/omitPropertiesSerializer.ts
+++ b/src/serializers/omitPropertiesSerializer.ts
@@ -6,11 +6,11 @@ export const createOmitPropertiesSerializer = (
    * A list of properties that should not be logged.
    */
   properties: readonly string[],
-): SerializerFn<unknown> => {
+): SerializerFn => {
   const uniquePropertySet = new Set(properties);
 
   if (uniquePropertySet.size === 0) {
-    return (input) => input;
+    return (input): unknown => input;
   }
 
   const uniqueProperties = Array.from(uniquePropertySet);

--- a/src/serializers/types.ts
+++ b/src/serializers/types.ts
@@ -1,2 +1,3 @@
 export type TrimmerFn = (input: unknown) => unknown;
-export type SerializerFn<T> = (input: T) => unknown;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SerializerFn = (input: any) => unknown;

--- a/src/serializers/types.ts
+++ b/src/serializers/types.ts
@@ -1,1 +1,2 @@
-export type SerializerFn = (input: unknown) => unknown;
+export type TrimmerFn = (input: unknown) => unknown;
+export type SerializerFn<T> = (input: T) => unknown;


### PR DESCRIPTION
## Purpose

Adds changes and refactors based on suggestions from https://github.com/seek-oss/logger/pull/141


## Approach

- Adds trimming to all serializers
- Reuses shared trimmer between serializers
- Excludes `stack` field from trimming in `err` and `errWithCause` serializers
- Defines the default `maxObjectDepth` once
- Condensed some related/duplicate tests
