### PR TITLE
Add support for configuring custom log levels

### DIFF
--- a/.changeset/ninety-bobcats-return.md
+++ b/.changeset/ninety-bobcats-return.md
@@ -1,0 +1,18 @@
+---
+'@seek/logger': minor
+---
+
+Add support for configuring custom log levels:
+
+```ts
+import createLogger from '@seek/logger';
+
+const logger = createLogger({
+  name: 'my-app',
+  customLevels: {
+    foo: 35,
+  },
+});
+
+logger.foo('Bar');
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,21 +12,22 @@ export { DEFAULT_OMIT_HEADER_NAMES } from './serializers';
 
 export { pino };
 
-export type LoggerOptions = pino.LoggerOptions &
-  FormatterOptions &
-  SerializerOptions;
-export type Logger = pino.Logger;
+export type LoggerOptions<CustomLevels extends string = never> =
+  pino.LoggerOptions<CustomLevels> & FormatterOptions & SerializerOptions;
+
+export type Logger<CustomLevels extends string = never> =
+  pino.Logger<CustomLevels>;
 
 /**
  * Creates a logger that can enforce a strict logged object shape.
  * @param opts - Logger options.
  * @param destination - Destination stream. Default: `pino.destination({ sync: true })`.
  */
-export default (
-  opts: LoggerOptions = {},
+export default <CustomLevels extends string = never>(
+  opts: LoggerOptions<CustomLevels> = {},
   destination: pino.DestinationStream = createDestination({ mock: false })
     .destination,
-): Logger => {
+): Logger<CustomLevels> => {
   opts.redact = redact.addDefaultRedactPathStrings(opts.redact);
 
   const serializers = createSerializers(opts);


### PR DESCRIPTION
I believe this should be entirely optional & backwards compatible. Anything I'm missing in that aspect? 