### PR TITLE
Can we just remove the args?

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,14 @@ interface LogFn {
 
 export type Logger<CustomLevels extends string = never> = Omit<
   pino.Logger<CustomLevels>,
-  'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | CustomLevels
+  | 'fatal'
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'debug'
+  | 'trace'
+  | 'child'
+  | CustomLevels
 > & {
   fatal: LogFn;
   error: LogFn;
@@ -34,6 +41,10 @@ export type Logger<CustomLevels extends string = never> = Omit<
   info: LogFn;
   debug: LogFn;
   trace: LogFn;
+  child: <ChildCustomLevels extends string = never>(
+    bindings: pino.Bindings,
+    options?: pino.ChildLoggerOptions<ChildCustomLevels>,
+  ) => Logger<CustomLevels | ChildCustomLevels>;
 } & Record<CustomLevels, LogFn>;
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,26 @@ export { pino };
 export type LoggerOptions<CustomLevels extends string = never> =
   pino.LoggerOptions<CustomLevels> & FormatterOptions & SerializerOptions;
 
-export type Logger<CustomLevels extends string = never> =
-  pino.Logger<CustomLevels>;
+// https://github.com/pinojs/pino/blob/427cbaf30d4717e7df5795c5ede7fdf3fa01eb5c/pino.d.ts#L322-L328
+interface LogFn {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  <T extends object>(obj: T, msg?: string, ...args: any[]): void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (obj: unknown, msg?: string, ...args: any[]): void;
+  (msg: string): void;
+}
+
+export type Logger<CustomLevels extends string = never> = Omit<
+  pino.Logger<CustomLevels>,
+  'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | CustomLevels
+> & {
+  fatal: LogFn;
+  error: LogFn;
+  warn: LogFn;
+  info: LogFn;
+  debug: LogFn;
+  trace: LogFn;
+} & Record<CustomLevels, LogFn>;
 
 /**
  * Creates a logger that can enforce a strict logged object shape.


### PR DESCRIPTION
## Purpose

Idea is to make the types tell you when your object is going to be omitted from the log, eg you now get this error: 

`Argument of type '{ error: Error; }' is not assignable to parameter of type 'string'.ts(2769)`

when doing something like: 
```ts
logger.info('Test log entry', { error: new Error('Test error') });
```



I have mistakenly done this too many times and it seems to be a fairly [common issue at SEEK](https://github.com/search?q=org%3ASEEK-Jobs+%2Flogger%5C.%5Cw%2B%5Cs*%5C%28%5Cs*%5B%27%22%60%5D%5B%5E%27%22%60%5D*%5B%27%22%60%5D%5Cs*%2C%5Cs*%5C%7B%2F&type=code) 😢 

## Approach

Butcher the types

## Notes

_Any notes for the reviewer, e.g. how to test, deployment approach, screen shots, etc._

## Issues

_Any github issue links related to this PR_
