### PR TITLE
Port pino-lambda functionality

### DIFF
--- a/.changeset/petite-mammals-clap.md
+++ b/.changeset/petite-mammals-clap.md
@@ -1,0 +1,38 @@
+---
+'@seek/logger': minor
+---
+
+Add support for capturing Lambda context in logs. This allows for consistent tracing and correlation across serverless functions.
+
+```typescript
+import createLogger, {
+  createLambdaContextTracker,
+  lambdaContextStorageProvider,
+} from '@seek/logger';
+
+// Create a context capture function
+const withRequest = createLambdaContextTracker();
+
+// Configure logger to include the context in all logs
+const logger = createLogger({
+  name: 'my-lambda-service',
+  mixin: () => ({
+    ...lambdaContextStorageProvider.getContext(),
+  }),
+});
+
+// Lambda handler with automated context capture
+export const handler = async (event, context) => {
+  // Capture the Lambda context at the start of each invocation
+  withRequest(event, context);
+
+  // All logs will now automatically include the Lambda context
+  logger.info({ event }, 'Lambda function invoked');
+
+  // Process your Lambda function...
+
+  logger.debug('Lambda execution completed');
+};
+```
+
+Please check the [README] for more details.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,12 @@ import { type FormatterOptions, createFormatters } from './formatters';
 import * as redact from './redact';
 import { type SerializerOptions, createSerializers } from './serializers';
 
+export {
+  createLambdaContextTracker,
+  type LambdaContextTrackerOptions,
+} from './lambda/request';
+export { lambdaContextStorageProvider } from './lambda/context';
+
 export { createDestination } from './destination/create';
 export { DEFAULT_OMIT_HEADER_NAMES } from './serializers';
 

--- a/src/lambda/context.test.ts
+++ b/src/lambda/context.test.ts
@@ -1,0 +1,25 @@
+import { lambdaContextStorageProvider } from './context';
+
+describe('lambdaContextStorageProvider', () => {
+  it('should set and get context', () => {
+    const context = { awsRequestId: 'test-123', customKey: 'value' };
+    lambdaContextStorageProvider.setContext(context);
+    const retrievedContext = lambdaContextStorageProvider.getContext();
+    expect(retrievedContext).toEqual(context);
+  });
+
+  it('should update context', () => {
+    const initialContext = { awsRequestId: 'test-123', customKey: 'value' };
+    lambdaContextStorageProvider.setContext(initialContext);
+
+    const updateValues = { customKey: 'newValue', anotherKey: 'anotherValue' };
+    lambdaContextStorageProvider.updateContext(updateValues);
+
+    const updatedContext = lambdaContextStorageProvider.getContext();
+    expect(updatedContext).toEqual({
+      awsRequestId: 'test-123',
+      customKey: 'newValue',
+      anotherKey: 'anotherValue',
+    });
+  });
+});

--- a/src/lambda/context.ts
+++ b/src/lambda/context.ts
@@ -1,0 +1,29 @@
+const CONTEXT_SYMBOL = Symbol.for('aws.lambda.runtime.context');
+
+interface GlobalContext {
+  [CONTEXT_SYMBOL]: ContextMap;
+}
+
+export interface ContextMap {
+  awsRequestId: string;
+  [key: string]: unknown;
+}
+
+export interface ContextStorageProvider {
+  getContext: () => ContextMap;
+  setContext: (map: ContextMap) => void;
+  updateContext: (values: Record<string, unknown>) => void;
+}
+
+export const lambdaContextStorageProvider: ContextStorageProvider = {
+  getContext: () => (global as unknown as GlobalContext)[CONTEXT_SYMBOL],
+  setContext: (map: ContextMap) =>
+    ((global as unknown as GlobalContext)[CONTEXT_SYMBOL] = map),
+  updateContext: (values: Record<string, unknown>) => {
+    const ctx = lambdaContextStorageProvider.getContext();
+    (global as unknown as GlobalContext)[CONTEXT_SYMBOL] = {
+      ...ctx,
+      ...values,
+    };
+  },
+};

--- a/src/lambda/request.test.ts
+++ b/src/lambda/request.test.ts
@@ -1,0 +1,39 @@
+import { lambdaContextStorageProvider } from './context';
+import { createLambdaContextTracker } from './request';
+
+describe('createLambdaContextTracker', () => {
+  it('should set the context with awsRequestId', () => {
+    const withRequest = createLambdaContextTracker();
+    const event = {};
+    const context = { awsRequestId: '12345' };
+
+    withRequest(event, context);
+
+    const ctx = lambdaContextStorageProvider.getContext();
+    expect(ctx).toEqual({ awsRequestId: '12345' });
+  });
+
+  it('should apply custom request mixin', () => {
+    type MyEvent = {
+      key: string;
+    };
+
+    const withRequest = createLambdaContextTracker<MyEvent>({
+      requestMixin: (event, context) => ({
+        customEventKey: event.key,
+        customContextKey: context.awsRequestId,
+      }),
+    });
+    const event = { key: 'value' };
+    const context = { awsRequestId: '12345' };
+
+    withRequest(event, context);
+
+    const ctx = lambdaContextStorageProvider.getContext();
+    expect(ctx).toEqual({
+      awsRequestId: '12345',
+      customEventKey: 'value',
+      customContextKey: '12345',
+    });
+  });
+});

--- a/src/lambda/request.ts
+++ b/src/lambda/request.ts
@@ -1,0 +1,44 @@
+import { type ContextMap, lambdaContextStorageProvider } from './context';
+
+export interface LambdaContext {
+  awsRequestId: string;
+  [key: string]: unknown;
+}
+
+export type LambdaEvent = Record<string, unknown>;
+
+export interface LambdaContextTrackerOptions<
+  TEvent extends LambdaEvent = LambdaEvent,
+  TContext extends LambdaContext = LambdaContext,
+> {
+  /**
+   * Per request level mixin with access to the Lambda
+   * event and context information for each request
+   */
+  requestMixin?: (event: TEvent, context: TContext) => Record<string, unknown>;
+}
+
+/**
+ * Creates a function for capturing Lambda request context across logging calls
+ * @param options The request options
+ */
+export const createLambdaContextTracker =
+  <
+    TEvent extends LambdaEvent = LambdaEvent,
+    TContext extends LambdaContext = LambdaContext,
+  >(
+    options: LambdaContextTrackerOptions<TEvent, TContext> = {},
+  ) =>
+  (event: TEvent, context: TContext): void => {
+    const ctx: ContextMap = {
+      awsRequestId: context.awsRequestId,
+    };
+
+    // handle custom request level mixins
+    if (options.requestMixin) {
+      const result = options.requestMixin(event, context);
+      Object.assign(ctx, result);
+    }
+
+    lambdaContextStorageProvider.setContext(ctx);
+  };


### PR DESCRIPTION
## Purpose

Resolves https://github.com/seek-oss/skuba/issues/930

Allows me to avoid doing this: https://github.com/seek-oss/skuba/pull/1924/files/5105e26cec2c2c2ab4d44822721ef5072140a037#r2159843555

Ports this functionality from [pino-lambda](https://github.com/FormidableLabs/pino-lambda).

Pino lambda uses destinations which would bypass our redact functionality so I've ported a basic version of it here.
