### PR TITLE
Export create logger as a named export

### DIFF
--- a/.changeset/loud-moles-push.md
+++ b/.changeset/loud-moles-push.md
@@ -4,7 +4,7 @@
 
 Export `createLogger` as a named export
 
-This improves forward compatibility with TypeScript & ESM. We've left the default export in place and there is no immediate need to migrate existing codebases.
+This improves forward compatibility with TypeScript & ESM. While the named export is recommended, there is no immediate need to migrate existing codebases, and we've left the default export in place.
 
 **Migration:**
 

--- a/.changeset/loud-moles-push.md
+++ b/.changeset/loud-moles-push.md
@@ -2,4 +2,13 @@
 '@seek/logger': minor
 ---
 
-Export createLogger as a named export
+Export `createLogger` as a named export for improved TypeScript compatibility
+
+**Migration:**
+
+```diff
+- import createLogger from '@seek/logger';
++ import { createLogger } from '@seek/logger';
+```
+
+This change is required for our eventual migration to ESM modules

--- a/.changeset/loud-moles-push.md
+++ b/.changeset/loud-moles-push.md
@@ -1,0 +1,5 @@
+---
+'@seek/logger': minor
+---
+
+Export createLogger as a named export

--- a/.changeset/loud-moles-push.md
+++ b/.changeset/loud-moles-push.md
@@ -2,7 +2,9 @@
 '@seek/logger': minor
 ---
 
-Export `createLogger` as a named export for improved TypeScript compatibility
+Export `createLogger` as a named export
+
+This improves forward compatibility with TypeScript & ESM. We've left the default export in place and there is no immediate need to migrate existing codebases.
 
 **Migration:**
 
@@ -10,5 +12,3 @@ Export `createLogger` as a named export for improved TypeScript compatibility
 - import createLogger from '@seek/logger';
 + import { createLogger } from '@seek/logger';
 ```
-
-This change is required for our eventual migration to ESM

--- a/.changeset/loud-moles-push.md
+++ b/.changeset/loud-moles-push.md
@@ -11,4 +11,4 @@ Export `createLogger` as a named export for improved TypeScript compatibility
 + import { createLogger } from '@seek/logger';
 ```
 
-This change is required for our eventual migration to ESM modules
+This change is required for our eventual migration to ESM

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It implements several SEEK customisations over [Pino], including:
 ## Usage
 
 ```typescript
-import createLogger, { createDestination } from '@seek/logger';
+import { createDestination, createLogger } from '@seek/logger';
 
 const { destination, stdoutMock } = createDestination({
   mock: config.environment === 'test',
@@ -150,8 +150,8 @@ This behaviour can be configured with the `omitHeaderNames` option.
 Example of extending the default header list:
 
 ```diff
--import createLogger from '@seek/logger';
-+import createLogger, { DEFAULT_OMIT_HEADER_NAMES } from '@seek/logger';
+-import { createLogger } from '@seek/logger';
++import { createLogger, DEFAULT_OMIT_HEADER_NAMES } from '@seek/logger';
 
 const logger = createLogger({
   name: 'my-app',
@@ -180,7 +180,7 @@ Consider flattening the log structure for performance, readability and cost savi
 You can customise your logger by providing [Pino options] like so:
 
 ```javascript
-import createLogger, { pino } from '@seek/logger';
+import { createLogger, pino } from '@seek/logger';
 
 const logger = createLogger(
   {
@@ -207,7 +207,7 @@ yarn add --dev pino-pretty
 Then selectively enable pretty printing when running your application locally:
 
 ```typescript
-import createLogger from '@seek/logger';
+import { createLogger } from '@seek/logger';
 
 const logger = createLogger({
   name: 'my-app',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,6 +19,7 @@ test('exports', () =>
     "x-envoy-upstream-service-time",
   ],
   "createDestination": [Function],
+  "createLogger": [Function],
   "default": [Function],
   "pino": [Function],
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export type Logger<CustomLevels extends string = never> = Omit<
  * @param opts - Logger options.
  * @param destination - Destination stream. Default: `pino.destination({ sync: true })`.
  */
-export default <CustomLevels extends string = never>(
+export const createLogger = <CustomLevels extends string = never>(
   opts: LoggerOptions<CustomLevels> = {},
   destination: pino.DestinationStream = createDestination({ mock: false })
     .destination,
@@ -105,3 +105,5 @@ export default <CustomLevels extends string = never>(
 
   return pino(opts, withRedaction(destination, opts.redactText));
 };
+
+export default createLogger;


### PR DESCRIPTION
Alternate approach to fix ESM compatibility to bundling: https://github.com/seek-oss/logger/pull/190

This would require everyone to migrate their import once they've moved to ESM. We can probably code-mod something via skuba to fix the majority