### PR TITLE
RFC: Support `eeeoh.fromEnvironment`

### DIFF
--- a/docs/eeeoh.md
+++ b/docs/eeeoh.md
@@ -10,21 +10,24 @@ These optional features are not relevant to applications that run outside of SEE
 To opt in:
 
 ```typescript
+// process.env.DD_ENV = 'production';
+// process.env.DD_SERVICE = 'my-component-name';
+// process.env.DD_VERSION = 'abcdefa.123';
+
 import { createLogger } from '@seek/logger';
 
-const base = {
-  env: 'production',
-  service: 'my-component-name',
-  version: 'abcdefa.123',
-} as const;
-
 const logger = createLogger({
-  base,
-  eeeoh: { datadog: 'tin' },
+  eeeoh: { datadog: 'tin', fromEnvironment: true },
 });
 ```
 
-In practice, you'd likely read `base` values from environment variables:
+The `fromEnvironment` option assumes that you have the following environment variables set:
+
+- `DD_ENV`
+- `DD_SERVICE`
+- `DD_VERSION` | `VERSION`
+
+You can accomplish a similar effect by manually configuring the [base attributes](#base-attributes) like so:
 
 ```typescript
 import { Eeeoh } from '@seek/logger';
@@ -35,8 +38,8 @@ import { Env } from 'skuba-dive';
 
 const base = {
   env: Env.oneOf(Eeeoh.envs)('DD_ENV'),
-  service: Env.string('SERVICE'),
-  version: Env.string('VERSION'),
+  service: Env.string('DD_SERVICE'),
+  version: Env.string('DD_VERSION'),
 } as const;
 
 const logger = createLogger({
@@ -108,20 +111,13 @@ Reach out if you have a need to set custom values for these attributes.
 ### Automat workload hosting
 
 Components deployed to Automat workload hosting receive `DD_ENV`, `DD_SERVICE`, `DD_VERSION` environment variables at runtime.
-Read the values in your application code.
+Read the values `fromEnvironment` in your application code:
 
 ```typescript
-import { Eeeoh } from '@seek/logger';
-
-// `Env` is like `process.env` but throws an error if the variable is not set.
-// We recommend failing fast over silently continuing in a misconfigured state.
-import { Env } from 'skuba-dive';
-
-const base = {
-  env: Env.oneOf(Eeeoh.envs)('DD_ENV'),
-  service: Env.string('DD_SERVICE'),
-  version: Env.string('DD_VERSION'),
-} as const;
+// src/framework/logging.ts
+const logger = createLogger({
+  eeeoh: { datadog: 'tin', fromEnvironment: true },
+});
 ```
 
 `DD_SERVICE` is derived from the following attributes:
@@ -144,7 +140,7 @@ metadata:
 
 Components deployed to Gantry workload hosting receive a `VERSION` environment variable at runtime.
 
-Pipe through `ENV` and `SERVICE` yourself:
+Pipe through `DD_ENV` and `DD_SERVICE` yourself:
 
 ```yaml
 # Values file: .gantry/production.yml | values.yaml
@@ -157,26 +153,19 @@ serviceName: my-component-name
 kind: Service
 service: '{{values "serviceName"}}'
 env:
-  ENV: '{{values "env"}}'
-  SERVICE: '{{values "serviceName"}}'
+  DD_ENV: '{{values "env"}}'
+  DD_SERVICE: '{{values "serviceName"}}'
 openTelemetry:
   useGantryServiceName: true
 ```
 
-Then, read the values in your application code:
+Then, read the values `fromEnvironment` in your application code:
 
 ```typescript
-import { Eeeoh } from '@seek/logger';
-
-// `Env` is like `process.env` but throws an error if the variable is not set.
-// We recommend failing fast over silently continuing in a misconfigured state.
-import { Env } from 'skuba-dive';
-
-const base = {
-  env: Env.oneOf(Eeeoh.envs)('ENV'),
-  service: Env.string('SERVICE'),
-  version: Env.string('VERSION'),
-} as const;
+// src/framework/logging.ts
+const logger = createLogger({
+  eeeoh: { datadog: 'tin', fromEnvironment: true },
+});
 ```
 
 ### AWS Lambda via AWS CDK
@@ -216,21 +205,13 @@ const datadog = new DatadogLambda(this, 'datadog', {
 datadog.addLambdaFunctions([worker]);
 ```
 
-Finally, read the values in your application code:
+Finally, read the values `fromEnvironment` in your application code:
 
 ```typescript
 // src/framework/logging.ts
-import { Eeeoh } from '@seek/logger';
-
-// `Env` is like `process.env` but throws an error if the variable is not set.
-// We recommend failing fast over silently continuing in a misconfigured state.
-import { Env } from 'skuba-dive';
-
-const base = {
-  env: Env.oneOf(Eeeoh.envs)('DD_ENV'),
-  service: Env.string('DD_SERVICE'),
-  version: Env.string('DD_VERSION'),
-} as const;
+const logger = createLogger({
+  eeeoh: { datadog: 'tin', fromEnvironment: true },
+});
 ```
 
 ### AWS Lambda via Serverless


### PR DESCRIPTION
https://seekchat.slack.com/archives/C05HN3VMZ2T/p1751945854499309?thread_ts=1751588999.185719&cid=C05HN3VMZ2T

- [ ] This is scoped to `eeeoh` rather than `eeeoh.datadog`. Thoughts?
- [ ] This apes Datadog tooling and directly couples to `DD_`. Thoughts?
- [ ] Bikeshed `fromEnvironment`
- [ ] Add TSDoc for the option