### PR TITLE
RFC: Allow no variables with `use: 'environment'`

### DIFF
--- a/.changeset/tiny-schools-fix.md
+++ b/.changeset/tiny-schools-fix.md
@@ -24,7 +24,7 @@ createLogger({
 });
 ```
 
-`@seek/logger` will now treat this as a type error to encourage adoption and stronger typing of our [built-in eeeoh integration](https://github.com/seek-oss/logger/blob/master/docs/eeeoh.md). Take particular note of the [`use: 'environment'` prerequisites](https://github.com/seek-oss/logger/blob/master/docs/eeeoh.md#getting-started) and option to instead define [`base` attributes](https://github.com/seek-oss/logger/blob/master/docs/eeeoh.md#base-attributes) before proceeding.
+`@seek/logger` will now treat this as a type error to encourage adoption and stronger typing of our [built-in eeeoh integration](https://github.com/seek-oss/logger/blob/master/docs/eeeoh.md). Take particular note of the [`use: 'environment'` prerequisites](https://github.com/seek-oss/logger/blob/master/docs/eeeoh.md#getting-started) before proceeding.
 
 ```typescript
 createLogger({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1636,6 +1636,37 @@ describe('eeeoh', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
+  test('use environment: no environment variables per test environment or Automat v1+', () => {
+    delete process.env.DD_ENV;
+    delete process.env.DD_SERVICE;
+    delete process.env.DD_VERSION;
+
+    delete process.env.VERSION;
+
+    createLogger(
+      { eeeoh: { datadog: 'tin', use: 'environment' } },
+      destination,
+    ).info('no environment variables');
+
+    expect(stdoutMock.calls).toMatchInlineSnapshot(`
+      [
+        {
+          "ddsource": "nodejs",
+          "eeeoh": {
+            "logs": {
+              "datadog": {
+                "enabled": true,
+                "tier": "tin",
+              },
+            },
+          },
+          "level": 30,
+          "msg": "no environment variables",
+        },
+      ]
+    `);
+  });
+
   test('use environment: valid environment variables', () => {
     process.env.DD_ENV = 'development';
     process.env.DD_SERVICE = 'deployment-service-name';
@@ -1688,38 +1719,6 @@ describe('eeeoh', () => {
           "level": 30,
           "msg": 2,
           "service": "deployment-service-name",
-        },
-      ]
-    `);
-  });
-
-  test('use mock', () => {
-    delete process.env.DD_ENV;
-    delete process.env.DD_SERVICE;
-    delete process.env.DD_VERSION;
-    delete process.env.VERSION;
-
-    createLogger({ eeeoh: { datadog: 'tin', use: 'mock' } }, destination).info(
-      Infinity,
-    );
-
-    expect(stdoutMock.calls).toMatchInlineSnapshot(`
-      [
-        {
-          "ddsource": "nodejs",
-          "ddtags": "env:test,version:test-version",
-          "eeeoh": {
-            "logs": {
-              "datadog": {
-                "enabled": true,
-                "tier": "tin",
-              },
-            },
-          },
-          "env": "test",
-          "level": 30,
-          "msg": null,
-          "service": "test-service",
         },
       ]
     `);


### PR DESCRIPTION
This is still relatively strict though I can be convinced to relax it:

- Requires either no or all `DD_` vars to be set
- Enforces non-empty strings
- Enforces Automat-y `env`s

One nice bit is that we can drop `use: 'mock'`.

Pending consensus that this is correct behaviour for Automat: https://seekchat.slack.com/archives/C08K7RUJ9T5/p1752481342644829?thread_ts=1752457974.882449&cid=C08K7RUJ9T5