### PR TITLE
Restore `pino.Logger` type compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import pino from 'pino';
+import pino, { type LoggerExtras } from 'pino';
 
 import base from './base';
 import { createDestination } from './destination/create';
@@ -104,7 +104,8 @@ export type Logger<CustomLevels extends string = never> = Omit<
       'customLevels'
     > & { customLevels: Record<ChildCustomLevels, number> },
   ): Logger<ChildCustomLevels>;
-} & Record<CustomLevels, LogFn>;
+} & Record<CustomLevels, LogFn> &
+  LoggerExtras<CustomLevels>;
 
 /**
  * Creates a logger that can enforce a strict logged object shape.


### PR DESCRIPTION
This restores a fallback `child(): pino.Logger` overload with the consequence that we cannot raise type errors on problematic bindings.

While it makes me sad, I think this may be a better option than #208 in the interest of removing barriers to eeeoh adoption.