### PR TITLE
Relax `env` validation

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,20 +1,15 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`eeeoh invalid base attributes {"env": "bad"} 1`] = `
-"@seek/logger found invalid values in base attributes. Review the documentation and ensure your deployment configures these correctly.
-env: expected "development" | "production" | "sandbox" | "test", received "bad""
-`;
-
 exports[`eeeoh invalid base attributes {"env": null, "service": null, "version": null} 1`] = `
 "@seek/logger found invalid values in base attributes. Review the documentation and ensure your deployment configures these correctly.
-env: expected "development" | "production" | "sandbox" | "test", received null
+env: expected non-empty string, received null
 service: expected non-empty string, received null
 version: expected non-empty string, received null"
 `;
 
 exports[`eeeoh invalid base attributes {"env": undefined, "version": undefined} 1`] = `
 "@seek/logger found invalid values in base attributes. Review the documentation and ensure your deployment configures these correctly.
-env: expected "development" | "production" | "sandbox" | "test", received undefined
+env: expected non-empty string, received undefined
 version: expected non-empty string, received undefined"
 `;
 
@@ -28,19 +23,9 @@ exports[`eeeoh invalid base attributes {"version": ""} 1`] = `
 version: expected non-empty string, received """
 `;
 
-exports[`eeeoh use environment: invalid environment variables {"DD_ENV": "bad"} 1`] = `
-"@seek/logger found invalid values in environment variables. Review the documentation and ensure your deployment configures these correctly.
-DD_ENV: expected "development" | "production" | "sandbox" | "test", received "bad""
-`;
-
-exports[`eeeoh use environment: invalid environment variables {"DD_ENV": "null", "DD_SERVICE": "null", "DD_VERSION": "null"} 1`] = `
-"@seek/logger found invalid values in environment variables. Review the documentation and ensure your deployment configures these correctly.
-DD_ENV: expected "development" | "production" | "sandbox" | "test", received "null""
-`;
-
 exports[`eeeoh use environment: invalid environment variables {"DD_ENV": undefined, "DD_VERSION": undefined} 1`] = `
 "@seek/logger found invalid values in environment variables. Review the documentation and ensure your deployment configures these correctly.
-DD_ENV: expected "development" | "production" | "sandbox" | "test", received undefined
+DD_ENV: expected non-empty string, received undefined
 DD_VERSION: expected non-empty string, received undefined"
 `;
 

--- a/src/eeeoh/eeeoh.ts
+++ b/src/eeeoh/eeeoh.ts
@@ -22,10 +22,8 @@ const parseNonEmptyString = chain(parseString, (value) =>
   value.trim().length ? success(value) : failure('String cannot be empty'),
 );
 
-const parseEnv = oneOf(...envs.map((env) => equals(env)));
-
 const parseBase = objectCompiled({
-  env: parseEnv,
+  env: parseNonEmptyString,
   service: parseNonEmptyString,
   version: parseNonEmptyString,
 });
@@ -278,7 +276,7 @@ type Base = {
    * See the documentation for more information:
    * https://github.com/seek-oss/logger/blob/master/docs/eeeoh.md
    */
-  env: Env;
+  env: Env | (string & {});
 
   /**
    * The name of the component, or the service name override on a
@@ -536,11 +534,6 @@ const sourceBaseValues = <CustomLevels extends string>(
 };
 
 const validate = {
-  env: (value: unknown) =>
-    parseEnv(value).error
-      ? `expected ${envs.map((e) => JSON.stringify(e)).join(' | ')}, received ${JSON.stringify(value)}`
-      : null,
-
   nonEmptyString: (value: unknown) =>
     parseNonEmptyString(value).error
       ? `expected non-empty string, received ${JSON.stringify(value)}`
@@ -557,7 +550,7 @@ const newValidationError = <
   { env, service, version }: { env: E; service: S; version: V },
 ) => {
   const issues = Object.entries({
-    [env]: validate.env(data?.[env]),
+    [env]: validate.nonEmptyString(data?.[env]),
     [service]: validate.nonEmptyString(data?.[service]),
     [version]: validate.nonEmptyString(data?.[version]),
   });


### PR DESCRIPTION
Cold feet, I don't think we should force this via tooling as part of the initial migration ask.