### PR TITLE
Remove eeeoh by default in mock destination

### DIFF
--- a/src/destination/mock.ts
+++ b/src/destination/mock.ts
@@ -35,7 +35,7 @@ export const DEFAULT_MOCK_OPTIONS = Object.freeze({
     '["x-request-id"]',
   ],
 
-  remove: ['environment', 'name', 'timestamp', 'version'],
+  remove: ['ddsource', 'eeeoh', 'env', 'environment', 'name', 'service', 'timestamp', 'version'],
 } as const satisfies MockOptions);
 
 export const createStdoutMock = (opts: MockOptions) => {


### PR DESCRIPTION
This will be noise in most tests and aligns with prior art defaults here.