### PR TITLE
RFC: Document that team cannot stand alone

### DIFF
--- a/docs/eeeoh.md
+++ b/docs/eeeoh.md
@@ -354,11 +354,11 @@ you can create a separate logger per team.
 
 ```typescript
 export const teamALogger = createLogger({
-  eeeoh: { datadog: 'tin', team: 'team-a', use: 'environment' },
+  eeeoh: { datadog: 'tin', team: 'owner-a', use: 'environment' },
 });
 
 export const teamBLogger = createLogger({
-  eeeoh: { datadog: 'tin', team: 'team-b', use: 'environment' },
+  eeeoh: { datadog: 'tin', team: 'owner-b', use: 'environment' },
 });
 ```
 
@@ -370,11 +370,11 @@ const noTeam = createLogger({
 });
 
 export const teamALogger = noTeam.child({
-  eeeoh: { datadog: 'tin', team: 'team-a' },
+  eeeoh: { datadog: 'tin', team: 'owner-a' },
 });
 
 export const teamBLogger = noTeam.child({
-  eeeoh: { datadog: 'tin', team: 'team-b' },
+  eeeoh: { datadog: 'tin', team: 'owner-b' },
 });
 ```
 
@@ -382,12 +382,12 @@ Or, by individual log:
 
 ```typescript
 logger.info(
-  { eeeoh: { datadog: 'tin', team: 'team-a' } },
+  { eeeoh: { datadog: 'tin', team: 'owner-a' } },
   'A message for team A',
 );
 
 logger.info(
-  { eeeoh: { datadog: 'tin', team: 'team-b' } },
+  { eeeoh: { datadog: 'tin', team: 'owner-b' } },
   'A message for team B',
 );
 ```

--- a/docs/eeeoh.md
+++ b/docs/eeeoh.md
@@ -370,19 +370,26 @@ const noTeam = createLogger({
 });
 
 export const teamALogger = noTeam.child({
-  eeeoh: { team: 'team-a' },
+  eeeoh: { datadog: 'tin', team: 'team-a' },
 });
 
 export const teamBLogger = noTeam.child({
-  eeeoh: { team: 'team-b' },
+  eeeoh: { datadog: 'tin', team: 'team-b' },
 });
 ```
 
 Or, by individual log:
 
 ```typescript
-logger.info({ eeeoh: { team: 'team-a' } }, 'A message for team A');
-logger.info({ eeeoh: { team: 'team-b' } }, 'A message for team B');
+logger.info(
+  { eeeoh: { datadog: 'tin', team: 'team-a' } },
+  'A message for team A',
+);
+
+logger.info(
+  { eeeoh: { datadog: 'tin', team: 'team-b' } },
+  'A message for team B',
+);
 ```
 
 [internal logging guidance]: https://backstage.myseek.xyz/docs/default/component/sig-backend-tooling/guidance/logging/


### PR DESCRIPTION
I can't see an obvious way to manage "deep merging" of `.child()`
bindings so you can't actually specify `team` by itself.

https://redirect.github.com/pinojs/pino/issues/1645

An alternative would be to move `team` nesting from `eeeoh` to `base` so
it is accepted as an independent binding.

```diff
  const logger = createLogger({
    eeeoh: {
      datadog: 'tin',
-     team: 'owner-a',
      use: 'environment',
    },
+   base: { team: 'owner-a' },
  });

  const childLogger = logger.child({
-   eeeoh: { datadog: 'tin', team: 'owner-b' },
+   team: 'owner-b',
  });
```