### PR TITLE
types: Make `logger.child()` bindings stricter

### DIFF
--- a/.changeset/thirty-flowers-sink.md
+++ b/.changeset/thirty-flowers-sink.md
@@ -1,0 +1,5 @@
+---
+'@seek/logger': patch
+---
+
+types: Make `logger.child()` bindings stricter

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -583,7 +583,7 @@ test('enforces a specified object interface', async () => {
   logger.info<ExampleMessageContext>(
     {
       activity: 'Testing Logger',
-      // @ts-expect-error - test assertion
+      // @ts-expect-error - test unrecognised inline property
       propertyNotAllowed: 'Linting error',
       input: {
         foo: 0xf00,
@@ -887,8 +887,9 @@ test('using custom levels does not leak into types or runtypes of other loggers'
   const logger = createLogger({ name: 'my-app' }, stream);
 
   expect(() => {
-    // @ts-expect-error - should not work
-    logger.something('foo');
+    logger
+      // @ts-expect-error - test unrecognised custom level
+      .something('foo');
   }).toThrow();
 
   logger.info('info');
@@ -902,9 +903,7 @@ test('using custom levels does not leak into types or runtypes of other loggers'
 test('bindings in child logger', () => {
   const logger = createLogger();
 
-  // We can't enforce type errors on these problematic bindings unless we are
-  // prepared to drop `LoggerExtras['child']` from our `Logger` type and break
-  // compatibility with the `pino.Logger` type.
+  // @ts-expect-error - test unsupported inline properties
   logger.child({
     env: 'test',
 
@@ -971,8 +970,10 @@ describe('eeeoh', () => {
     void (() =>
       logger.info(
         {
-          // @ts-expect-error - asserting type error on complex inline config
-          eeeoh: { datadog: ['bronze', { info: 'silver' }] },
+          eeeoh: {
+            // @ts-expect-error - test unsupported complex inline config
+            datadog: ['bronze', { info: 'silver' }],
+          },
         },
         'silver from inline equal to level',
       ));
@@ -1103,7 +1104,7 @@ describe('eeeoh', () => {
     );
     logger.debug(
       {
-        // @ts-expect-error - asserting runtime behaviour on invalid config
+        // @ts-expect-error - test runtime behaviour on invalid config
         eeeoh: { datadog: NaN },
       },
       'tin from default because invalid inline config is ignored',
@@ -1435,6 +1436,7 @@ describe('eeeoh', () => {
       destination,
     ).child({
       eeeoh: {
+        // @ts-expect-error - test unrecognised tier
         datadog: 'XXX',
       },
     });
@@ -1502,7 +1504,7 @@ describe('eeeoh', () => {
     const logger = createLogger(
       {
         base: {
-          // @ts-expect-error - asserting type error
+          // @ts-expect-error - test unsupported base property
           eeeoh: 'test',
         },
       },
@@ -1795,6 +1797,7 @@ describe('eeeoh', () => {
     logger.info('tin from my team');
 
     logger
+      // @ts-expect-error - test unsupported child properties
       .child({
         ddtags: 'sometag:some-value',
         ddsource: 'some-other-source',
@@ -1802,15 +1805,25 @@ describe('eeeoh', () => {
       })
       .info('silver from another team');
 
-    // @ts-expect-error - testings things
-    logger.info({ ddtags: 'sometag:some-value' }, 'tin from my team');
+    logger.info(
+      {
+        // @ts-expect-error - test unsupported inline property
+        ddtags: 'sometag:some-value',
+      },
+      'tin from my team',
+    );
     logger.info(
       { eeeoh: { datadog: 'bronze', team: 'new-owner' } },
       'tin from my team',
     );
 
-    // @ts-expect-error - testings things
-    logger.info({ ddsource: 'some-other-source' }, 'tin from my team');
+    logger.info(
+      {
+        // @ts-expect-error - test unsupported inline property
+        ddsource: 'some-other-source',
+      },
+      'tin from my team',
+    );
     logger.info(
       { eeeoh: { datadog: 'bronze', team: 'new-owner' } },
       'tin from my team',

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ interface LoggerExtras<
    * @returns a child logger instance.
    */
   child<ChildCustomLevels extends string = never>(
-    bindings: pino.Bindings,
+    bindings: Eeeoh.Bindings<CustomLevels> & pino.Bindings,
     options?: pino.ChildLoggerOptions<ChildCustomLevels>,
   ): pino.Logger<CustomLevels | ChildCustomLevels>;
 


### PR DESCRIPTION
I think this was unblocked by #221.