### PR TITLE
Use Other Validation Library

### DIFF
--- a/.changeset/tall-horses-occur.md
+++ b/.changeset/tall-horses-occur.md
@@ -2,4 +2,4 @@
 '@seek/logger': patch
 ---
 
-Replace configuration parsing library from `pure-parse` to `sury`
+deps: Switch configuration parsing library from `pure-parse` to `sury`

--- a/.changeset/tall-horses-occur.md
+++ b/.changeset/tall-horses-occur.md
@@ -1,0 +1,5 @@
+---
+'@seek/logger': patch
+---
+
+Replace configuration parsing library from `pure-parse` to `sury`

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,6 @@
 import { Jest } from 'skuba';
 
-export default Jest.mergePreset({
+const preset = Jest.mergePreset({
   coveragePathIgnorePatterns: ['src/testing'],
   coverageThreshold: {
     global: {
@@ -12,4 +12,14 @@ export default Jest.mergePreset({
   },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/test\\.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*(?<!\\.res))\\.js$': '$1',
+  },
 });
+
+export default {
+  ...preset,
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*(?<!\\.res))\\.js$': '$1',
+  },
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,4 @@ export default Jest.mergePreset({
   },
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/test\\.ts'],
-  moduleNameMapper: {
-    '^(\\.{1,2}/.*(?<!\\.res))\\.js$': '$1',
-  },
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,6 @@
 import { Jest } from 'skuba';
 
-const preset = Jest.mergePreset({
+export default Jest.mergePreset({
   coveragePathIgnorePatterns: ['src/testing'],
   coverageThreshold: {
     global: {
@@ -16,10 +16,3 @@ const preset = Jest.mergePreset({
     '^(\\.{1,2}/.*(?<!\\.res))\\.js$': '$1',
   },
 });
-
-export default {
-  ...preset,
-  moduleNameMapper: {
-    '^(\\.{1,2}/.*(?<!\\.res))\\.js$': '$1',
-  },
-};

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@changesets/get-github-info": "0.6.0",
     "@types/fast-redact": "3.0.4",
     "@types/split2": "4.2.3",
-    "skuba": "12.1.1",
+    "skuba": "12.2.0-main-20250826233130",
     "split2": "4.2.0"
   },
   "packageManager": "pnpm@10.14.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fast-redact": "^3.5.0",
     "pino": "^9.8.0",
     "pino-std-serializers": "^7.0.0",
-    "sury": "10.0.4"
+    "sury": "^10.0.4"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fast-redact": "^3.5.0",
     "pino": "^9.8.0",
     "pino-std-serializers": "^7.0.0",
-    "sury": "^10.0.4"
+    "sury": "11.0.0-alpha.3"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fast-redact": "^3.5.0",
     "pino": "^9.8.0",
     "pino-std-serializers": "^7.0.0",
-    "pure-parse": "^1.0.1"
+    "sury": "10.0.4"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dtrim": "^1.11.0",
     "fast-redact": "^3.5.0",
     "pino": "^9.8.0",
-    "pino-std-serializers": "^7.0.0",
+    "pino-std-serializers": "^7.0.0"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       sury:
-        specifier: ^10.0.4
-        version: 10.0.4
+        specifier: 11.0.0-alpha.3
+        version: 11.0.0-alpha.3
     devDependencies:
       '@changesets/cli':
         specifier: 2.29.5
@@ -3705,10 +3705,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  sury@10.0.4:
-    resolution: {integrity: sha512-dWKqOv+6D4AwGCjeKyaWr157RVBtvnPUp1I6RxReYD1dYuBl4k6oUd/t5INh1mBhUuAEC9SP+rZmIunCyNjXzQ==}
+  sury@11.0.0-alpha.3:
+    resolution: {integrity: sha512-gYMHfco6+IqXNgxnhImtpx3sIb6q1GTbpY9ygTOmdzP2R3muMBt3TqEnAmkFVTDJNOj6T8/zTORjOs2vGPvaJA==}
     peerDependencies:
-      rescript: 11.x
+      rescript: 12.x
     peerDependenciesMeta:
       rescript:
         optional: true
@@ -8470,7 +8470,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sury@10.0.4: {}
+  sury@11.0.0-alpha.3: {}
 
   synckit@0.11.11:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       pino-std-serializers:
         specifier: ^7.0.0
         version: 7.0.0
-      sury:
-        specifier: 11.0.0-alpha.3
-        version: 11.0.0-alpha.3
     devDependencies:
       '@changesets/cli':
         specifier: 2.29.6
@@ -42,6 +39,9 @@ importers:
       split2:
         specifier: 4.2.0
         version: 4.2.0
+      sury:
+        specifier: 11.0.0-alpha.3
+        version: 11.0.0-alpha.3
       tsdown:
         specifier: 0.14.2
         version: 0.14.2(typescript@5.9.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       sury:
-        specifier: 10.0.4
+        specifier: ^10.0.4
         version: 10.0.4
     devDependencies:
       '@changesets/cli':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3
       skuba:
-        specifier: 12.1.1
-        version: 12.1.1(@babel/core@7.28.0)(@jest/transform@30.0.5)(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(babel-jest@30.0.5(@babel/core@7.28.0))(jest-util@30.0.5)
+        specifier: 12.2.0-main-20250826233130
+        version: 12.2.0-main-20250826233130(@babel/core@7.28.0)(@jest/transform@30.0.5)(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(babel-jest@30.0.5(@babel/core@7.28.0))(jest-util@30.0.5)
       split2:
         specifier: 4.2.0
         version: 4.2.0
@@ -1667,8 +1667,8 @@ packages:
       eslint: '>=9.9.1'
       typescript: '>=5.5.4'
 
-  eslint-config-skuba@7.1.0:
-    resolution: {integrity: sha512-8BJjPV6iBm1xd0VnZV3+yKrilbLy+kA0hU7yZfw4PrZykvG6Hqb5CjuSYPpVKnoEKFoYepCmJAH5GbJyY5wwDw==}
+  eslint-config-skuba@7.1.1-main-20250826233130:
+    resolution: {integrity: sha512-t2ws5M4gRqJIBmxPBVnwCrAppotz1UCWCBcJi3EemWgZh1IxXzn0IzRNvxidEMAFeGaL1oJU0obAJs/13QoSLg==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       eslint: '>=9.11.1'
@@ -1739,8 +1739,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-skuba@1.0.0:
-    resolution: {integrity: sha512-V+3zRELQBW8HWGUUY4L4l9GSNNm6ZcD1qqou43Xw1wiFbslMDl2TC6ubT0vH7+LqSQ0vyfCkBfQvpJdIlDbacw==}
+  eslint-plugin-skuba@1.0.1-main-20250826233130:
+    resolution: {integrity: sha512-RetdXEUVBIR/L9sIna+WIbCNWDei9ThmJxlIQGnZ1EXKYSMJZxYiMiIFnCCm2IxVOkr2JEJwz4AI7u47TGc+0w==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       eslint: '>=9.11.1'
@@ -3509,8 +3509,8 @@ packages:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
 
-  skuba@12.1.1:
-    resolution: {integrity: sha512-+i//xxWSwA24xUlG20eQonLw4MwycRvEbxjkIL5gkucoJMnIG4QMbO1iHv9teCOfgrW69GnbzBstAcwJ7VB6XA==}
+  skuba@12.2.0-main-20250826233130:
+    resolution: {integrity: sha512-STvYILEzfrjs3KT87Lth8r7C6MvwNkxzi/AF0iYA3PpdCov/BzAcQ7QPvBxl1ZK1XaAJUcQ2ca1WuacWF+gqAw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6065,11 +6065,11 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-skuba@7.1.0(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(jest@30.0.5(@types/node@22.17.1)(ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2)))(typescript@5.9.2):
+  eslint-config-skuba@7.1.1-main-20250826233130(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(jest@30.0.5(@types/node@22.17.1)(ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2)))(typescript@5.9.2):
     dependencies:
       eslint: 9.33.0
       eslint-config-seek: 14.6.0(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(jest@30.0.5(@types/node@22.17.1)(ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2)))(typescript@5.9.2)
-      eslint-plugin-skuba: 1.0.0(eslint@9.33.0)(typescript-eslint@8.39.1(eslint@9.33.0)(typescript@5.9.2))
+      eslint-plugin-skuba: 1.0.1-main-20250826233130(eslint@9.33.0)(typescript-eslint@8.39.1(eslint@9.33.0)(typescript@5.9.2))
       eslint-plugin-yml: 1.18.0(eslint@9.33.0)
       typescript: 5.9.2
       typescript-eslint: 8.39.1(eslint@9.33.0)(typescript@5.9.2)
@@ -6162,7 +6162,7 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-skuba@1.0.0(eslint@9.33.0)(typescript-eslint@8.39.1(eslint@9.33.0)(typescript@5.9.2)):
+  eslint-plugin-skuba@1.0.1-main-20250826233130(eslint@9.33.0)(typescript-eslint@8.39.1(eslint@9.33.0)(typescript@5.9.2)):
     dependencies:
       eslint: 9.33.0
       typescript-eslint: 8.39.1(eslint@9.33.0)(typescript@5.9.2)
@@ -8193,7 +8193,7 @@ snapshots:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
 
-  skuba@12.1.1(@babel/core@7.28.0)(@jest/transform@30.0.5)(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(babel-jest@30.0.5(@babel/core@7.28.0))(jest-util@30.0.5):
+  skuba@12.2.0-main-20250826233130(@babel/core@7.28.0)(@jest/transform@30.0.5)(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(babel-jest@30.0.5(@babel/core@7.28.0))(jest-util@30.0.5):
     dependencies:
       '@esbuild-plugins/tsconfig-paths': 0.1.2(esbuild@0.25.9)(typescript@5.9.2)
       '@eslint/migrate-config': 1.3.8(eslint@9.33.0)
@@ -8210,7 +8210,7 @@ snapshots:
       enquirer: 2.4.1
       esbuild: 0.25.9
       eslint: 9.33.0
-      eslint-config-skuba: 7.1.0(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(jest@30.0.5(@types/node@22.17.1)(ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2)))(typescript@5.9.2)
+      eslint-config-skuba: 7.1.1-main-20250826233130(@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2))(@typescript-eslint/utils@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(jest@30.0.5(@types/node@22.17.1)(ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2)))(typescript@5.9.2)
       execa: 5.1.1
       fast-glob: 3.3.3
       find-up: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
       pino-std-serializers:
         specifier: ^7.0.0
         version: 7.0.0
-      pure-parse:
-        specifier: ^1.0.1
-        version: 1.0.1
+      sury:
+        specifier: 10.0.4
+        version: 10.0.4
     devDependencies:
       '@changesets/cli':
         specifier: 2.29.5
@@ -3278,9 +3278,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pure-parse@1.0.1:
-    resolution: {integrity: sha512-UsgFso+aJp//oxsf0nKiSb+dV+/Vf+BC+0kongb650F5iz6cyVjGe8ZSF2iTjSJPqSFAr5MErEOzhQd2YiosAA==}
-
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
@@ -3707,6 +3704,14 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  sury@10.0.4:
+    resolution: {integrity: sha512-dWKqOv+6D4AwGCjeKyaWr157RVBtvnPUp1I6RxReYD1dYuBl4k6oUd/t5INh1mBhUuAEC9SP+rZmIunCyNjXzQ==}
+    peerDependencies:
+      rescript: 11.x
+    peerDependenciesMeta:
+      rescript:
+        optional: true
 
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
@@ -7881,8 +7886,6 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pure-parse@1.0.1: {}
-
   pure-rand@7.0.1: {}
 
   quansync@0.2.10: {}
@@ -8466,6 +8469,8 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  sury@10.0.4: {}
 
   synckit@0.11.11:
     dependencies:

--- a/src/eeeoh/eeeoh.ts
+++ b/src/eeeoh/eeeoh.ts
@@ -7,7 +7,7 @@ export const envs = ['development', 'production', 'sandbox', 'test'] as const;
 
 export type Env = (typeof envs)[number];
 
-const nonEmptyString = S.trim(S.min(S.string, 1, 'String cannot be empty'));
+const nonEmptyString = S.min(S.trim(S.string), 1, 'String cannot be empty');
 
 const parseNonEmptyString = S.compile(nonEmptyString, 'Any', 'Output', 'Sync');
 

--- a/src/eeeoh/eeeoh.ts
+++ b/src/eeeoh/eeeoh.ts
@@ -555,7 +555,8 @@ const sourceBaseValues = <CustomLevels extends string>(
 const validate = {
   nonEmptyString: (value: unknown) => {
     try {
-      return parseNonEmptyString(value);
+      parseNonEmptyString(value);
+      return null;
     } catch {
       return `expected non-empty string, received ${JSON.stringify(value)}`;
     }

--- a/src/eeeoh/eeeoh.ts
+++ b/src/eeeoh/eeeoh.ts
@@ -43,7 +43,8 @@ export type DatadogConfig<CustomLevels extends string = never> =
 
 type LevelToTier = (level: number) => DatadogTier | false | null;
 
-const tierByLevelMapSchema = S.record(datadogTierSchema);
+const tierByLevelMapSchema: S.Schema<Partial<Record<string, DatadogTier>>> =
+  S.record(datadogTierSchema);
 
 const datadogTierByLevelSchema = S.schema([
   datadogTierSchema,

--- a/src/eeeoh/eeeoh.ts
+++ b/src/eeeoh/eeeoh.ts
@@ -1,17 +1,5 @@
 import pino from 'pino';
-import {
-  type Infer,
-  chain,
-  dictionary,
-  equals,
-  failure,
-  objectCompiled,
-  oneOf,
-  optional,
-  parseString,
-  success,
-  tuple,
-} from 'pure-parse';
+import * as S from 'sury';
 
 import { ddtags } from './ddtags.js';
 
@@ -19,32 +7,34 @@ export const envs = ['development', 'production', 'sandbox', 'test'] as const;
 
 export type Env = (typeof envs)[number];
 
-const parseNonEmptyString = chain(parseString, (value) =>
-  value.trim().length ? success(value) : failure('String cannot be empty'),
-);
+const nonEmptyString = S.trim(S.min(S.string, 1, 'String cannot be empty'));
 
-const parseBase = objectCompiled({
-  env: parseNonEmptyString,
-  service: parseNonEmptyString,
-  version: parseNonEmptyString,
+const parseNonEmptyString = S.compile(nonEmptyString, 'Any', 'Output', 'Sync');
+
+const baseSchema = S.schema({
+  env: nonEmptyString,
+  service: nonEmptyString,
+  version: nonEmptyString,
 });
 
-type ParseBase = Infer<typeof parseBase>;
+const parseBase = S.compile(baseSchema, 'Any', 'Output', 'Sync');
 
-const parseDatadogTier = oneOf(
-  equals('zero'),
-  equals('tin'),
-  equals('tin-plus'),
-  equals('tin-plus-plus'),
-  equals('bronze'),
-  equals('bronze-plus'),
-  equals('bronze-plus-plus'),
-  equals('silver'),
-  equals('silver-plus'),
-  equals('silver-plus-plus'),
-);
+type ParseBase = ReturnType<typeof parseBase>;
 
-export type DatadogTier = Infer<typeof parseDatadogTier>;
+const datadogTierSchema = S.union([
+  'zero',
+  'tin',
+  'tin-plus',
+  'tin-plus-plus',
+  'bronze',
+  'bronze-plus',
+  'bronze-plus-plus',
+  'silver',
+  'silver-plus',
+  'silver-plus-plus',
+]);
+
+export type DatadogTier = S.Output<typeof datadogTierSchema>;
 
 export type DatadogConfig<CustomLevels extends string = never> =
   | DatadogTier
@@ -53,22 +43,26 @@ export type DatadogConfig<CustomLevels extends string = never> =
 
 type LevelToTier = (level: number) => DatadogTier | false | null;
 
-const parseTierByLevelMap = dictionary<string, DatadogTier>(
-  parseString,
-  parseDatadogTier,
-);
+const tierByLevelMapSchema = S.record(datadogTierSchema);
 
-const parseDatadogTierByLevel = tuple([parseDatadogTier, parseTierByLevelMap]);
+const datadogTierByLevelSchema = S.schema([
+  datadogTierSchema,
+  tierByLevelMapSchema,
+]);
 
-const parseEeeohConfig = objectCompiled<Config<string>>({
-  datadog: oneOf(parseDatadogTier, parseDatadogTierByLevel, equals(false)),
-  team: optional(parseNonEmptyString),
+const eeeohConfigSchema = S.schema({
+  datadog: S.union([datadogTierSchema, datadogTierByLevelSchema, false]),
+  team: S.optional(nonEmptyString),
 });
 
-const parseEeeohField = objectCompiled<NonNullable<Fields['eeeoh']>>({
-  datadog: oneOf(parseDatadogTier, equals(false)),
-  team: optional(parseNonEmptyString),
+const parseEeeohConfig = S.compile(eeeohConfigSchema, 'Any', 'Output', 'Sync');
+
+const eeeohFieldSchema = S.schema({
+  datadog: S.union([datadogTierSchema, false]),
+  team: S.optional(nonEmptyString),
 });
+
+const parseEeeohField = S.compile(eeeohFieldSchema, 'Any', 'Output', 'Sync');
 
 export type Config<CustomLevels extends string> = {
   /**
@@ -503,12 +497,11 @@ const getConfigForLogger = <CustomLevels extends string>(
     return null;
   }
 
-  const result = parseEeeohConfig(eeeoh);
-  if (result.error) {
+  try {
+    return parseEeeohConfig(eeeoh);
+  } catch {
     return null;
   }
-
-  return result.value;
 };
 
 const getTierForLevel = (
@@ -560,10 +553,13 @@ const sourceBaseValues = <CustomLevels extends string>(
 };
 
 const validate = {
-  nonEmptyString: (value: unknown) =>
-    parseNonEmptyString(value).error
-      ? `expected non-empty string, received ${JSON.stringify(value)}`
-      : null,
+  nonEmptyString: (value: unknown) => {
+    try {
+      return parseNonEmptyString(value);
+    } catch {
+      return `expected non-empty string, received ${JSON.stringify(value)}`;
+    }
+  },
 };
 
 const newValidationError = <
@@ -598,31 +594,23 @@ const getBaseOrThrow = <CustomLevels extends string>(
     return;
   }
 
-  const result = parseBase(baseValues);
+  try {
+    return parseBase(baseValues);
+  } catch {
+    if ('use' in opts.eeeoh && opts.eeeoh.use === 'environment') {
+      throw newValidationError(
+        '@seek/logger found invalid values in environment variables. Review the documentation and ensure your deployment configures these correctly.',
+        process.env,
+        { env: 'DD_ENV', service: 'DD_SERVICE', version: 'DD_VERSION' },
+      );
+    }
 
-  if (!result.error) {
-    const { env, service, version } = result.value;
-
-    return {
-      env,
-      service,
-      version,
-    };
-  }
-
-  if ('use' in opts.eeeoh && opts.eeeoh.use === 'environment') {
     throw newValidationError(
-      '@seek/logger found invalid values in environment variables. Review the documentation and ensure your deployment configures these correctly.',
-      process.env,
-      { env: 'DD_ENV', service: 'DD_SERVICE', version: 'DD_VERSION' },
+      '@seek/logger found invalid values in base attributes. Review the documentation and ensure your deployment configures these correctly.',
+      opts.base,
+      { env: 'env', service: 'service', version: 'version' },
     );
   }
-
-  throw newValidationError(
-    '@seek/logger found invalid values in base attributes. Review the documentation and ensure your deployment configures these correctly.',
-    opts.base,
-    { env: 'env', service: 'service', version: 'version' },
-  );
 };
 
 type CreateOptions<CustomLevels extends string> = Options<CustomLevels> &
@@ -723,22 +711,22 @@ export const createOptions = <CustomLevels extends string>(
     let tier: DatadogTier | false | undefined;
 
     if ('eeeoh' in input) {
-      const result = parseEeeohField(input.eeeoh);
+      try {
+        const result = parseEeeohField(input.eeeoh);
 
-      if (result?.tag === 'success') {
-        tier = result.value.datadog;
+        tier = result.datadog;
 
-        if (result.value.team) {
+        if (result.team) {
           return {
             tags: ddtags({
               env: base?.env,
-              team: result.value.team,
+              team: result.team,
               version: base?.version,
             }),
-            tier: result.value.datadog,
+            tier: result.datadog,
           };
         }
-      }
+      } catch {}
     }
 
     const { levelToTier, tags } = getCacheableConfig(logger);

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -6,6 +6,6 @@ export default defineConfig({
   exports: true,
   dts: {
     // Bundles type declarations for the specified packages
-    resolve: ['sury']
-  }
+    resolve: ['sury'],
+  },
 });


### PR DESCRIPTION
`pure-parse` is taking a [little too long to respond to me](https://github.com/johannes-lindgren/pure-parse/pull/148) and I want to get a move on with ESM migration.

So I'm switching to [sury](https://github.com/DZakh/sury).

<img width="884" height="371" alt="image" src="https://github.com/user-attachments/assets/ffab5944-b998-4967-9b5d-b3a069b2ae1a" />

<img width="486" height="265" alt="image" src="https://github.com/user-attachments/assets/d51b37ba-b287-4359-aff7-f8451d03fbf1" />
